### PR TITLE
Removing log4j jar from bin.xml to avoid it being copied to carbon-home/lib/runtimes/ext since its provided by the carbon framework it self

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -916,7 +916,6 @@
                 <include>com.sun.jersey:jersey-json:jar</include>
                 <include>com.sun.jersey:jersey-client:jar</include>
                 <include>dom4j:dom4j:jar</include>
-                <include>log4j:log4j:jar</include>
             </includes>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <useTransitiveDependencies>true</useTransitiveDependencies>


### PR DESCRIPTION
Public Jira: https://jira.wso2telco.com/jira/browse/IDSDEV-298

In a previous PR[1] when moving common dependencies shared by webapps to carbon-home/repository/lib/ext, log4j jarwhich had been embedded in the webapp to provide custom log4j.properties file also had been copied. To allow webapp use global log4j configuration, this had to be removed.



[1] https://github.com/WSO2Telco/product-ids/pull/22/files#diff-706a8cde3da32b80c7315b73265c106cR121