### PR TITLE
Adding hashids dependency, adding sms_hashkey_contextid_mapping table, changes in LICENSE

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -12,660 +12,661 @@ below is and where the actual text of the license can be found.
 
 Name                                                                            Type           License
 ---------------------------------------------------------------------------------------------------------
-abdera_1.0.0.wso2v3.jar                                                         bundle         apache2   907
-activation-1.1.jar                                                              jarinbundle    cddl1     1802
-addressing-1.6.1-wso2v20.mar                                                    bundle         apache2   9597
-ajaxtags_1.3.0.beta-rc7-wso2v1.jar                                              bundle         apache2   905
-annogen_0.1.0.wso2v1.jar                                                        bundle         apache2   942
-ant-contrib-1.0b3.jar                                                           jar            apache2   549
-antlr-runtime_3.2.0.wso2v1.jar                                                  bundle         bsd       817
-antlr_3.2.0.wso2v1.jar                                                          bundle         bsd       838
-ant_1.7.0.wso2v1.jar                                                            bundle         apache2   1012
-aopalliance-1.0.jar                                                             jar            apache2   512
-apache-zookeeper_3.3.4.wso2v1.jar                                               bundle         apache2   4219
-apacheds-avl-partition-1.5.7.jar                                                jarinbundle    apache2   467
-apacheds-core-1.5.7.jar                                                         jarinbundle    apache2   441
-apacheds-core-annotations-1.5.7.jar                                             jarinbundle    apache2   440
-apacheds-core-api-1.5.7.jar                                                     jarinbundle    apache2   448
-apacheds-core-avl-1.5.7.jar                                                     jarinbundle    apache2   446
-apacheds-core-constants-1.5.7.jar                                               jarinbundle    apache2   471
-apacheds-core-entry-1.5.7.jar                                                   jarinbundle    apache2   472
-apacheds-core-jndi-1.5.7.jar                                                    jarinbundle    apache2   469
-apacheds-i18n-1.5.7.jar                                                         jarinbundle    apache2   439
-apacheds-interceptor-kerberos-1.5.7.jar                                         jarinbundle    apache2   447
-apacheds-jdbm-1.5.7.jar                                                         jarinbundle    apache2   461
-apacheds-jdbm-partition-1.5.7.jar                                               jarinbundle    apache2   475
-apacheds-jdbm-store-1.5.7.jar                                                   jarinbundle    apache2   473
-apacheds-kerberos-shared-1.5.7.jar                                              jarinbundle    apache2   456
-apacheds-ldif-partition-1.5.7.jar                                               jarinbundle    apache2   476
-apacheds-protocol-changepw-1.5.7.jar                                            jarinbundle    apache2   465
-apacheds-protocol-dhcp-1.5.7.jar                                                jarinbundle    apache2   454
-apacheds-protocol-dns-1.5.7.jar                                                 jarinbundle    apache2   457
-apacheds-protocol-kerberos-1.5.7.jar                                            jarinbundle    apache2   470
-apacheds-protocol-ldap-1.5.7.jar                                                jarinbundle    apache2   477
-apacheds-protocol-ntp-1.5.7.jar                                                 jarinbundle    apache2   453
-apacheds-protocol-shared-1.5.7.jar                                              jarinbundle    apache2   459
-apacheds-server-annotations-1.5.7.jar                                           jarinbundle    apache2   449
-apacheds-server-jndi-1.5.7.jar                                                  jarinbundle    apache2   462
-apacheds-server-replication-1.5.7.jar                                           jarinbundle    apache2   474
-apacheds-utils-1.5.7.jar                                                        jarinbundle    apache2   466
-apacheds-xdbm-base-1.5.7.jar                                                    jarinbundle    apache2   479
-apacheds-xdbm-search-1.5.7.jar                                                  jarinbundle    apache2   478
-apacheds-xdbm-tools-1.5.7.jar                                                   jarinbundle    apache2   463
-apacheds_1.5.7.wso2v4.jar                                                       bundle         apache2   6220
-asm-3.3.1.jar                                                                   jar            bsd       1268
-asm_1.5.3.wso2v1.jar                                                            bundle         bsd       1438
-asm_3.1.0.wso2v1.jar                                                            bundle         bsd       735
-axiom_1.2.11.wso2v11.jar                                                        bundle         apache2   8489
-axion_1.0.0.M3-dev-wso2v1.jar                                                   bundle         apache2   2826
-axis2-jaxbri_1.6.1.wso2v11.jar                                                  bundle         apache2   6219
-axis2-jaxbri_1.6.1.wso2v19.jar                                                  bundle         apache2   8488
-axis2-jibx_1.6.1.wso2v11.jar                                                    bundle         apache2   6218
-axis2-json_1.6.1.wso2v20.jar                                                    bundle         apache2   9596
-axis2-transport-mail_1.1.0.wso2v13.jar                                          bundle         apache2   4381
-axis2_1.6.1.wso2v20.jar                                                         bundle         apache2   9595
-backport-util-concurrent_3.1.0.wso2v1.jar                                       bundle         apache2   1007
-bcel_5.2.0.wso2v1.jar                                                           bundle         apache2   1466
-bcprov-jdk14-138.jar                                                            jarinbundle    bouncy    451
-bcprov-jdk15-132.jar                                                            jar            bouncy    285
-bcprov-jdk15on-1.52.jar                                                         jarinbundle    bouncy    1819
-bcprov-jdk15on_1.52.0.wso2v1.jar                                                bundle         bouncy    8485
-cassandra-thrift_1.2.13.wso2v4.jar                                              bundle         apache2   4379
-cglib_2.2.0.wso2v1.jar                                                          bundle         apache2   2760
-com.google.gson_2.3.1.jar                                                       bundle         apache2   1143
-com.google.gson_2.7.0.jar                                                       bundle         apache2   1853
-com.google.guava_15.0.0.jar                                                     bundle         apache2   792
-com.google.guava_19.0.0.jar                                                     bundle         apache2   1627
-commons-beanutils-1.7.0.jar                                                     jarinbundle    apache2   383
-commons-cli_1.2.0.wso2v1.jar                                                    bundle         apache2   922
-commons-codec_1.4.0.wso2v1.jar                                                  bundle         apache2   980
-commons-collections-3.2.1.jar                                                   bundle         apache2   514
-commons-collections_3.2.2.wso2v1.jar                                            bundle         apache2   6268
-commons-configuration_1.6.0.wso2v1.jar                                          bundle         apache2   933
-commons-dbcp_1.4.0.wso2v1.jar                                                   bundle         apache2   962
-commons-digester-1.8.jar                                                        jarinbundle    apache2   384
-commons-fileupload_1.3.2.wso2v1.jar                                             bundle         apache2   9594
-commons-httpclient_3.1.0.wso2v3.jar                                             bundle         apache2   8483
-commons-io_2.4.0.wso2v1.jar                                                     bundle         apache2   4217
-commons-lang-2.6.0.wso2v1.jar                                                   bundle         apache2   664
-commons-lang-2.6.jar                                                            bundle         apache2   506
-commons-lang_2.6.0.wso2v1.jar                                                   bundle         apache2   940
-commons-logging-1.1.1.jar                                                       jar            apache2   274
-commons-pool_1.5.6.wso2v1.jar                                                   bundle         apache2   1009
-commons-primitives_1.0.0.wso2v1.jar                                             bundle         apache2   2799
-compass_2.0.1.wso2v2.jar                                                        bundle         apache2   897
-cors-filter_1.7.0.wso2v1.jar                                                    bundle         apache2   2106
-csrfguard_3.1.0.wso2v2.jar                                                      bundle         bsd       8482
-cxf-bundle-2.7.16.jar                                                           bundle         apache2   1154
-cxf-xjc-boolean-3.0.2.jar                                                       jar            apache2   1153
-cxf-xjc-bug671-3.0.2.jar                                                        jar            apache2   1152
-cxf-xjc-dv-3.0.2.jar                                                            jar            apache2   1151
-cxf-xjc-runtime-3.0.2.jar                                                       bundle         apache2   1150
-cxf-xjc-ts-3.0.2.jar                                                            jar            apache2   1149
-derby-10.4.1.3.jar                                                              jarinbundle    apache2   695
-derbytools-10.4.1.3.jar                                                         jarinbundle    apache2   696
-disruptor_3.3.2.wso2v2.jar                                                      bundle         apache2   4377
-ehcache-core-2.5.1.jar                                                          jar            apache2   267
-ehcache_1.5.0.wso2v3.jar                                                        bundle         apache2   852
-encoder_1.2.0.wso2v1.jar                                                        bundle         apache2   4030
-gdata-core_1.47.0.wso2v1.jar                                                    bundle         apache2   1481
-geronimo-connector_2.0.1.wso2v1.jar                                             bundle         apache2   1657
-geronimo-j2ee-connector_1.5_spec_1.0.0.wso2v1.jar                               bundle         apache2   1647
-geronimo-jaxws_2.2_spec-1.0.jar                                                 bundle         apache2   395
-geronimo-jms_1.1_spec-1.1.0.wso2v1.jar                                          bundle         apache2   661
-geronimo-jta_1.1_spec-1.1.jar                                                   jar            apache2   1066
-geronimo-kernel_2.0.1.wso2v1.jar                                                bundle         apache2   2802
-geronimo-saaj_1.3_spec_1.0.0.wso2v3.jar                                         bundle         apache2   893
-geronimo-spec-javamail_1.3.0.rc51-wso2v1.jar                                    bundle         apache2   2819
-geronimo-spec-jms_1.1.0.rc4-wso2v1.jar                                          bundle         apache2   2828
-geronimo-transaction_2.0.1.wso2v1.jar                                           bundle         apache2   1635
-google-api-client-1.17.0-rc.jar                                                 jarinbundle    apache2   889
-google-api-services-admin-directory_v1-rev28-1.17.0-rc.jar                      jarinbundle    apache2   888
-google-http-client-1.17.0-rc.jar                                                jarinbundle    apache2   887
-google-http-client-jackson2-1.17.0-rc.jar                                       jarinbundle    apache2   886
-google-oauth-client-1.17.0-rc.jar                                               jarinbundle    apache2   885
-groovy-all_2.3.9.jar                                                            bundle         apache2   1338
-guava-15.0.jar                                                                  jarinbundle    apache2   1553
-guice_3.0.0.wso2v1.jar                                                          bundle         apache2   1505
-h2-1.3.175.jar                                                                  jarinbundle    epl1      1999
-h2_1.3.175.wso2v1.jar                                                           bundle         apache2   9731
-hazelcast_3.5.4.wso2v2.jar                                                      bundle         apache2   8481
-hector-core_1.1.4.wso2v1.jar                                                    bundle         apache2   2878
-hibernate_3.2.5.ga-wso2v1.jar                                                   bundle         lgpl2     1467
-high-scale-lib_1.0.0.wso2v1.jar                                                 bundle         apache2   4216
-hsqldb_1.8.0.7wso2v1.jar                                                        bundle         bsd       1583
-httpasyncclient-4.0-beta3.jar                                                   jar            apache2   280
-httpclient-4.2.5.jar                                                            jar            apache2   548
-httpclient_4.3.1.wso2v2.jar                                                     bundle         apache2   4214
-httpcore-4.2.4.jar                                                              jar            apache2   533
-httpcore-nio-4.2.4.jar                                                          jar            apache2   534
-httpcore_4.3.3.wso2v1.jar                                                       bundle         apache2   3638
-httpmime_4.3.1.wso2v2.jar                                                       bundle         apache2   4375
-io.dropwizard.metrics.core_3.1.2.jar                                            bundle         apache2   1305
-io.dropwizard.metrics.jvm_3.1.2.jar                                             bundle         apache2   1302
-jackson-annotations-2.5.0.jar                                                   jarinbundle    apache2   1552
-jackson-core-2.1.3.jar                                                          jarinbundle    apache2   884
-jackson-core-2.5.0.jar                                                          jarinbundle    apache2   1551
-jackson-databind-2.5.0.jar                                                      jarinbundle    apache2   1550
-java-property-utils_1.9.0.wso2v1.jar                                            bundle         apache2   2201
-javasysmon_0.3.3.wso2v1.jar                                                     bundle         bsd       721
-javax.cache.wso2_4.4.9.jar                                                      bundle         cddl+gpl  1960
-javax.ws.rs-api-2.0-m10.jar                                                     bundle         cddl+gpl  263
-jaxb-impl-2.2.6.jar                                                             jar            cddl1     1148
-jaxb-xjc-2.2.6.jar                                                              jar            cddl1     1147
-jaxb_2.2.5.wso2v1.jar                                                           bundle         cddl1     883
-jdbc-pool_7.0.34.wso2v2.jar                                                     bundle         apache2   3637
-jdom_1.0.0.wso2v1.jar                                                           bundle         apache2   693
-jericho-html-2.4.jar                                                            jarinbundle    epl1      363
-jettison-1.3.4.jar                                                              bundle         apache2   542
-jettison_1.3.4.wso2v1.jar                                                       bundle         apache2   2162
-jibx_1.2.1.wso2v1.jar                                                           bundle         apache2   1518
-joda-time_2.8.2.wso2v1.jar                                                      bundle         apache2   6879
-json-simple_1.1.0.wso2v1.jar                                                    bundle         apache2   828
-json_1.0.0.wso2v1.jar                                                           bundle         apache2   2361
-json_2.0.0.wso2v1.jar                                                           bundle         apache2   971
-json_3.0.0.wso2v1.jar                                                           bundle         apache2   6503
-jsr305-1.3.9.jar                                                                jarinbundle    apache2   883
-jstl_1.2.1.wso2v2.jar                                                           bundle         cddl1     2204
-js_1.7.0.R4wso2v1.jar                                                           bundle         mpl10     2199
-kaptcha_2.3.0.wso2v1.jar                                                        bundle         apache2   854
-libthrift_0.7.0.wso2v2.jar                                                      bundle         apache2   912
-libthrift_0.8.0.wso2v1.jar                                                      bundle         apache2   1117
-libthrift_0.9.2.wso2v1.jar                                                      bundle         apache2   5912
-lucene_5.2.1.wso2v1.jar                                                         bundle         apache2   4502
-mail-1.4.jar                                                                    jarinbundle    cddl1     1802
-mina-core-2.0.0-RC1.jar                                                         jarinbundle    apache2   481
-neethi-3.0.3.jar                                                                bundle         apache2   1146
-neethi_2.0.4.wso2v5.jar                                                         bundle         apache2   6267
-nekohtml-1.9.10.jar                                                             jarinbundle    apache2   1576
-net.minidev.json-smart_1.3.0.jar                                                bundle         apache2   1337
-nimbus-jose-jwt_2.26.1.wso2v3.jar                                               bundle         apache2   4885
-noggit_0.6.0.wso2v1.jar                                                         bundle         apache2   4211
-ode-agents-1.3.5-wso2v16.jar                                                    bundle         apache2   7553
-ode-axis2-1.3.5-wso2v16.jar                                                     bundle         apache2   7552
-ode-bpel-api-1.3.5-wso2v16.jar                                                  bundle         apache2   7551
-ode-bpel-api-jca-1.3.5-wso2v16.jar                                              bundle         apache2   7550
-ode-bpel-compiler-1.3.5-wso2v16.jar                                             bundle         apache2   7549
-ode-bpel-connector-1.3.5-wso2v16.jar                                            bundle         apache2   7548
-ode-bpel-dao-1.3.5-wso2v16.jar                                                  bundle         apache2   7547
-ode-bpel-epr-1.3.5-wso2v16.jar                                                  bundle         apache2   7546
-ode-bpel-extensions-e4x-1.3.5-wso2v16.jar                                       bundle         apache2   7545
-ode-bpel-extensions-long-running-1.3.5-wso2v16.jar                              bundle         apache2   7544
-ode-bpel-obj-1.3.5-wso2v16.jar                                                  bundle         apache2   7543
-ode-bpel-ql-1.3.5-wso2v16.jar                                                   bundle         apache2   7542
-ode-bpel-runtime-1.3.5-wso2v16.jar                                              bundle         apache2   7541
-ode-bpel-schemas-1.3.5-wso2v16.jar                                              bundle         apache2   7540
-ode-bpel-store-1.3.5-wso2v16.jar                                                bundle         apache2   7539
-ode-dao-hibernate-1.3.5-wso2v16.jar                                             bundle         apache2   7538
-ode-dao-hibernate-db-1.3.5-wso2v16.jar                                          bundle         apache2   7537
-ode-dao-jpa-1.3.5-wso2v16.jar                                                   bundle         apache2   7536
-ode-jacob-1.3.5-wso2v16.jar                                                     bundle         apache2   7535
-ode-jca-ra-1.3.5-wso2v16.jar                                                    bundle         apache2   7534
-ode-jca-server-1.3.5-wso2v16.jar                                                bundle         apache2   7533
-ode-scheduler-simple-1.3.5-wso2v16.jar                                          bundle         apache2   7532
-ode-utils-1.3.5-wso2v16.jar                                                     bundle         apache2   7531
-ode_1.3.5.wso2v16.jar                                                           bundle         apache2   7530
-oltu_1.0.0.wso2v3.jar                                                           bundle         apache2   6502
-opencsv-1.8.jar                                                                 jarinbundle    apache2   368
-opencsv_1.8.0.wso2v1.jar                                                        bundle         apache2   928
-openid4java_1.0.0.wso2v2.jar                                                    bundle         apache2   6216
-opensaml_2.6.4.wso2v3.jar                                                       bundle         apache2   8480
-openspml2-192-20100413.jar                                                      jarinbundle    apache2   882
-openxri-client-1.2.0.jar                                                        jarinbundle    apache2   433
-openxri-syntax-1.2.0.jar                                                        jarinbundle    apache2   434
-org.apache.felix.gogo.command_0.10.0.v201209301215.jar                          bundle         apache2   1134
-org.apache.felix.gogo.runtime_0.10.0.v201209301036.jar                          bundle         apache2   1133
-org.apache.felix.gogo.shell_0.10.0.v201212101605.jar                            bundle         apache2   1132
-org.apache.geronimo.specs.geronimo-jpa_2.0_spec_1.1.0.jar                       bundle         apache2   702
-org.apache.openjpa_2.2.0.wso2v1.jar                                             bundle         apache2   1665
-org.apache.servicemix.bundles.jaxb-api-2.0_4.0.0.m1.jar                         bundle         apache2   1226
-org.eclipse.core.contenttype_3.4.200.v20130326-1255.jar                         bundle         epl1      1131
-org.eclipse.core.expressions_3.4.500.v20130515-1343.jar                         bundle         epl1      1130
-org.eclipse.core.jobs_3.5.300.v20130429-1813.jar                                bundle         epl1      1129
-org.eclipse.core.runtime_3.9.0.v20130326-1255.jar                               bundle         epl1      1128
-org.eclipse.ecf.filetransfer_5.0.0.v20130604-1622.jar                           bundle         epl1      1127
-org.eclipse.ecf.identity_3.2.0.v20130604-1622.jar                               bundle         epl1      1126
-org.eclipse.ecf.provider.filetransfer.httpclient_4.0.200.v20120319-0616.jar     bundle         epl1      289
-org.eclipse.ecf.provider.filetransfer_3.2.0.v20130604-1622.jar                  bundle         epl1      1125
-org.eclipse.ecf_3.2.0.v20130604-1622.jar                                        bundle         epl1      1124
-org.eclipse.equinox.app_1.3.100.v20130327-1442.jar                              bundle         epl1      1123
-org.eclipse.equinox.common_3.6.200.v20130402-1505.jar                           bundle         epl1      1122
-org.eclipse.equinox.concurrent_1.1.0.v20130327-1442.jar                         bundle         epl1      1121
-org.eclipse.equinox.console_1.0.100.v20130429-0953.jar                          bundle         epl1      1120
-org.eclipse.equinox.ds_1.4.101.v20130813-1853.jar                               bundle         epl1      1119
-org.eclipse.equinox.frameworkadmin.equinox_1.0.500.v20130327-2119.jar           bundle         epl1      1118
-org.eclipse.equinox.frameworkadmin_2.0.100.v20130327-2119.jar                   bundle         epl1      1117
-org.eclipse.equinox.http.helper_1.1.0.wso2v1.jar                                bundle         epl1      839
-org.eclipse.equinox.http.servlet_1.1.400.v20130418-1354.jar                     bundle         epl1      1116
-org.eclipse.equinox.jsp.jasper_1.0.400.v20120522-2049.jar                       bundle         epl1      388
-org.eclipse.equinox.launcher_1.3.0.v20130327-1440.jar                           bundle         epl1      1115
-org.eclipse.equinox.p2.artifact.repository_1.1.100.v20110519.jar                bundle         epl1      337
-org.eclipse.equinox.p2.console_1.0.300.v20130327-2119.jar                       bundle         epl1      1114
-org.eclipse.equinox.p2.core_2.3.0.v20130327-2119.jar                            bundle         epl1      1113
-org.eclipse.equinox.p2.director.app_1.0.300.v20130819-1621.jar                  bundle         epl1      1112
-org.eclipse.equinox.p2.directorywatcher_1.0.300.v20130327-2119.jar              bundle         epl1      1110
-org.eclipse.equinox.p2.director_2.3.0.v20130526-0335.jar                        bundle         epl1      1111
-org.eclipse.equinox.p2.engine_2.3.0.v20130526-2122-wso2v1.jar                   bundle         epl1      3873
-org.eclipse.equinox.p2.extensionlocation_1.2.100.v20130327-2119.jar             bundle         epl1      1109
-org.eclipse.equinox.p2.garbagecollector_1.0.200.v20130327-2119.jar              bundle         epl1      1108
-org.eclipse.equinox.p2.jarprocessor_1.0.300.v20130327-2119.jar                  bundle         epl1      1107
-org.eclipse.equinox.p2.metadata.repository_1.2.100.v20130327-2119.jar           bundle         epl1      1106
-org.eclipse.equinox.p2.metadata_2.2.0.v20130523-1557.jar                        bundle         epl1      1105
-org.eclipse.equinox.p2.publisher_1.2.0.v20110511.jar                            bundle         epl1      306
-org.eclipse.equinox.p2.repository.tools_2.1.0.v20130327-2119.jar                bundle         epl1      1104
-org.eclipse.equinox.p2.repository_2.3.0.v20130412-2032.jar                      bundle         epl1      1103
-org.eclipse.equinox.p2.touchpoint.eclipse_2.1.0.v20110511-wso2v1.jar            bundle         epl1      703
-org.eclipse.equinox.p2.touchpoint.natives_1.1.100.v20130327-2119.jar            bundle         epl1      1102
-org.eclipse.equinox.p2.transport.ecf_1.0.100.v20110902-0807.jar                 bundle         epl1      369
-org.eclipse.equinox.p2.updatechecker_1.1.200.v20130327-2119.jar                 bundle         epl1      1101
-org.eclipse.equinox.p2.updatesite_1.0.400.v20130515-2028.jar                    bundle         epl1      1100
-org.eclipse.equinox.preferences_3.5.100.v20130422-1538.jar                      bundle         epl1      1099
-org.eclipse.equinox.registry_3.5.301.v20130717-1549.jar                         bundle         epl1      1098
-org.eclipse.equinox.security_1.2.0.v20130424-1801.jar                           bundle         epl1      1097
-org.eclipse.equinox.simpleconfigurator.manipulator_2.0.0.v20130327-2119.jar     bundle         epl1      1096
-org.eclipse.equinox.simpleconfigurator_1.0.400.v20130327-2119.jar               bundle         epl1      1095
-org.eclipse.equinox.util_1.0.500.v20130404-1337.jar                             bundle         epl1      1094
-org.eclipse.jdt.core.compiler.batch_3.10.2.v20150120-1634.jar                   bundle         epl1      1141
-org.eclipse.osgi.services_3.3.100.v20130513-1956.jar                            bundle         epl1      1093
-org.eclipse.osgi_3.9.1.v20130814-1242.jar                                       bundle         epl1      1092
-org.eclipse.wst.jsdt.debug.rhino.debugger_1.0.300.v201109150503.jar             bundle         epl1      558
-org.eclipse.wst.jsdt.debug.transport_1.0.100.v201109150330.jar                  bundle         epl1      557
-org.jaggeryjs.hostobjects.db_0.12.6.jar                                         bundle         apache2   1817
-org.jaggeryjs.hostobjects.feed_0.12.6.jar                                       bundle         apache2   1816
-org.jaggeryjs.hostobjects.file_0.12.6.jar                                       bundle         apache2   1815
-org.jaggeryjs.hostobjects.jaggeryparser_0.12.6.jar                              bundle         apache2   1814
-org.jaggeryjs.hostobjects.log_0.12.6.jar                                        bundle         apache2   1813
-org.jaggeryjs.hostobjects.registry_0.12.6.jar                                   bundle         apache2   1812
-org.jaggeryjs.hostobjects.stream_0.12.6.jar                                     bundle         apache2   1811
-org.jaggeryjs.hostobjects.uri_0.12.6.jar                                        bundle         apache2   1810
-org.jaggeryjs.hostobjects.web_0.12.6.jar                                        bundle         apache2   1809
-org.jaggeryjs.hostobjects.xhr_0.12.6.jar                                        bundle         apache2   1808
-org.jaggeryjs.hostobjects.xslt_0.12.6.jar                                       bundle         apache2   1807
-org.jaggeryjs.jaggery.app.mgt_0.12.6.jar                                        bundle         apache2   1806
-org.jaggeryjs.jaggery.core_0.12.6.jar                                           bundle         apache2   1805
-org.jaggeryjs.jaggery.deployer_0.12.6.jar                                       bundle         apache2   1804
-org.jaggeryjs.jaggery.tools_0.12.6.jar                                          bundle         apache2   1803
-org.jaggeryjs.modules.email_1.5.3.jar                                           bundle         apache2   1802
-org.jaggeryjs.modules.oauth_1.5.3.jar                                           bundle         apache2   1801
-org.jaggeryjs.modules.process_1.5.3.jar                                         bundle         apache2   1800
-org.jaggeryjs.modules.sso_1.5.3.jar                                             bundle         apache2   1799
-org.jaggeryjs.modules.uuid_1.5.3.jar                                            bundle         apache2   1798
-org.jaggeryjs.modules.ws_1.5.3.jar                                              bundle         apache2   1797
-org.jaggeryjs.scriptengine_0.12.6.jar                                           bundle         apache2   1796
-org.restlet_2.3.0.wso2v1.jar                                                    bundle         apache2   4501
-org.sat4j.core_2.3.5.v201308161310.jar                                          bundle         epl1+lgpl21091
-org.sat4j.pb_2.3.5.v201308161310.jar                                            bundle         epl1+lgpl21090
-org.wso2.balana.utils_1.0.5.jar                                                 bundle         apache2   9909
-org.wso2.balana_1.0.5.jar                                                       bundle         apache2   9908
-org.wso2.carbon.addressing_4.4.9.jar                                            bundle         apache2   9593
-org.wso2.carbon.application.deployer_4.4.9.jar                                  bundle         apache2   9592
-org.wso2.carbon.application.upload_4.5.4.jar                                    bundle         apache2   8684
-org.wso2.carbon.attachment.mgt.skeleton_4.4.9.jar                               bundle         apache2   8475
-org.wso2.carbon.attachment.mgt_4.4.9.jar                                        bundle         apache2   8474
-org.wso2.carbon.authenticator.proxy_4.4.9.jar                                   bundle         apache2   9591
-org.wso2.carbon.authenticator.stub_4.4.9.jar                                    bundle         apache2   9590
-org.wso2.carbon.base_4.4.9.jar                                                  bundle         apache2   9589
-org.wso2.carbon.bootstrap-4.4.9.jar                                             bundle         apache2   9544
-org.wso2.carbon.bpel.b4p_4.4.9.jar                                              bundle         apache2   8470
-org.wso2.carbon.bpel.cluster.notifier_4.4.9.jar                                 bundle         apache2   8469
-org.wso2.carbon.bpel.common_4.4.9.jar                                           bundle         apache2   8468
-org.wso2.carbon.bpel.deployer_4.4.9.jar                                         bundle         apache2   8467
-org.wso2.carbon.bpel.skeleton_4.4.9.jar                                         bundle         apache2   8466
-org.wso2.carbon.bpel_4.4.9.jar                                                  bundle         apache2   8465
-org.wso2.carbon.captcha.mgt_4.2.0.jar                                           bundle         apache2   2154
-org.wso2.carbon.captcha.mgt_4.5.2.jar                                           bundle         apache2   4499
-org.wso2.carbon.claim.mgt.stub_5.2.2.jar                                        bundle         apache2   9907
-org.wso2.carbon.claim.mgt.ui_5.2.2.jar                                          bundle         apache2   9906
-org.wso2.carbon.claim.mgt_5.2.2.jar                                             bundle         apache2   9905
-org.wso2.carbon.cluster.mgt.core_4.4.9.jar                                      bundle         apache2   9588
-org.wso2.carbon.core.bootup.validator_4.4.9.jar                                 bundle         apache2   9587
-org.wso2.carbon.core.commons.stub_4.4.9.jar                                     bundle         apache2   9585
-org.wso2.carbon.core.common_4.4.9.jar                                           bundle         apache2   9586
-org.wso2.carbon.core.services_4.4.9.jar                                         bundle         apache2   9584
-org.wso2.carbon.core_4.4.9.jar                                                  bundle         apache2   9583
-org.wso2.carbon.cxf.ext-4.7.0.jar                                               bundle         apache2   8203
-org.wso2.carbon.databridge.agent_5.1.1.jar                                      bundle         apache2   9200
-org.wso2.carbon.databridge.commons.binary_5.1.1.jar                             bundle         apache2   9199
-org.wso2.carbon.databridge.commons.thrift_5.1.1.jar                             bundle         apache2   9198
-org.wso2.carbon.databridge.commons_5.1.1.jar                                    bundle         apache2   9197
-org.wso2.carbon.deployment.synchronizer.subversion_4.5.4.jar                    bundle         apache2   8451
-org.wso2.carbon.deployment.synchronizer_4.5.4.jar                               bundle         apache2   8450
-org.wso2.carbon.directory.server.manager.common_5.2.2.jar                       bundle         apache2   9904
-org.wso2.carbon.directory.server.manager.stub_5.2.2.jar                         bundle         apache2   9903
-org.wso2.carbon.directory.server.manager.ui_5.2.2.jar                           bundle         apache2   9902
-org.wso2.carbon.directory.server.manager_5.2.2.jar                              bundle         apache2   9901
-org.wso2.carbon.discovery.cxf_4.7.0.jar                                         bundle         apache2   8445
-org.wso2.carbon.event.admin_4.5.4.jar                                           bundle         apache2   8444
-org.wso2.carbon.event.application.deployer_5.1.1.jar                            bundle         apache2   9192
-org.wso2.carbon.event.client.stub_4.5.4.jar                                     bundle         apache2   8442
-org.wso2.carbon.event.client_4.5.4.jar                                          bundle         apache2   8441
-org.wso2.carbon.event.common_4.5.4.jar                                          bundle         apache2   8440
-org.wso2.carbon.event.core_4.5.4.jar                                            bundle         apache2   8439
-org.wso2.carbon.event.output.adapter.cassandra_5.1.1.jar                        bundle         apache2   9177
-org.wso2.carbon.event.output.adapter.core_5.1.1.jar                             bundle         apache2   9176
-org.wso2.carbon.event.output.adapter.email_5.1.1.jar                            bundle         apache2   9175
-org.wso2.carbon.event.output.adapter.http_5.1.1.jar                             bundle         apache2   9174
-org.wso2.carbon.event.output.adapter.jms_5.1.1.jar                              bundle         apache2   9173
-org.wso2.carbon.event.output.adapter.kafka_5.1.1.jar                            bundle         apache2   9172
-org.wso2.carbon.event.output.adapter.logger_5.1.1.jar                           bundle         apache2   9171
-org.wso2.carbon.event.output.adapter.mqtt_5.1.1.jar                             bundle         apache2   9170
-org.wso2.carbon.event.output.adapter.rdbms_5.1.1.jar                            bundle         apache2   9169
-org.wso2.carbon.event.output.adapter.sms_5.1.1.jar                              bundle         apache2   9168
-org.wso2.carbon.event.output.adapter.soap_5.1.1.jar                             bundle         apache2   9167
-org.wso2.carbon.event.output.adapter.ui_5.1.1.jar                               bundle         apache2   9166
-org.wso2.carbon.event.output.adapter.websocket.local_5.1.1.jar                  bundle         apache2   9165
-org.wso2.carbon.event.output.adapter.websocket_5.1.1.jar                        bundle         apache2   9164
-org.wso2.carbon.event.output.adapter.wso2event_5.1.1.jar                        bundle         apache2   9163
-org.wso2.carbon.event.processor.manager.commons_5.1.1.jar                       bundle         apache2   9159
-org.wso2.carbon.event.processor.manager.core_5.1.1.jar                          bundle         apache2   9158
-org.wso2.carbon.event.publisher.admin_5.1.1.jar                                 bundle         apache2   9154
-org.wso2.carbon.event.publisher.core_5.1.1.jar                                  bundle         apache2   9153
-org.wso2.carbon.event.stream.admin_5.1.1.jar                                    bundle         apache2   9139
-org.wso2.carbon.event.stream.core_5.1.1.jar                                     bundle         apache2   9138
-org.wso2.carbon.event.ws_4.5.4.jar                                              bundle         apache2   8417
-org.wso2.carbon.extension.identity.authenticator.emailotp.connector-2.0.2.jar   bundle         apache2   9809
-org.wso2.carbon.extension.identity.authenticator.office365.connector-1.0.0.jar  bundle         apache2   9808
-org.wso2.carbon.extension.identity.authenticator.smsotp.connector-2.0.4.jar     bundle         apache2   9807
-org.wso2.carbon.extension.identity.authenticator.totp.connector-2.0.1.jar       bundle         apache2   9806
-org.wso2.carbon.extension.identity.authenticator.twitter.connector-1.0.5.jar    bundle         apache2   9805
-org.wso2.carbon.feature.mgt.core_4.4.9.jar                                      bundle         apache2   9582
-org.wso2.carbon.feature.mgt.services_4.4.9.jar                                  bundle         apache2   9581
-org.wso2.carbon.feature.mgt.stub_4.4.9.jar                                      bundle         apache2   9580
-org.wso2.carbon.feature.mgt.ui_4.4.9.jar                                        bundle         apache2   9579
-org.wso2.carbon.framework.exporter_4.4.9.jar                                    bundle         apache2   9578
-org.wso2.carbon.humantask.cleanup.scheduler_4.4.9.jar                           bundle         apache2   8411
-org.wso2.carbon.humantask.coordination.module_4.4.9.jar                         bundle         apache2   8410
-org.wso2.carbon.humantask.deployer_4.4.9.jar                                    bundle         apache2   8409
-org.wso2.carbon.humantask.skeleton_4.4.9.jar                                    bundle         apache2   8408
-org.wso2.carbon.humantask_4.4.9.jar                                             bundle         apache2   8407
-org.wso2.carbon.i18n_4.4.9.jar                                                  bundle         apache2   9577
-org.wso2.carbon.identity.application.authentication.endpoint.util_5.2.2.jar     bundle         apache2   9900
-org.wso2.carbon.identity.application.authentication.framework_5.2.2.jar         bundle         apache2   9899
-org.wso2.carbon.identity.application.authenticator.basicauth_5.1.2.jar          bundle         apache2   9898
-org.wso2.carbon.identity.application.authenticator.facebook-5.1.2.jar           bundle         apache2   9804
-org.wso2.carbon.identity.application.authenticator.fido_5.1.2.jar               bundle         apache2   9897
-org.wso2.carbon.identity.application.authenticator.google-5.1.2.jar             bundle         apache2   9803
-org.wso2.carbon.identity.application.authenticator.iwa_5.1.2.jar                bundle         apache2   9896
-org.wso2.carbon.identity.application.authenticator.live-5.1.2.jar               bundle         apache2   9802
-org.wso2.carbon.identity.application.authenticator.oidc-5.1.2.jar               bundle         apache2   9801
-org.wso2.carbon.identity.application.authenticator.passive.sts-5.1.2.jar        bundle         apache2   9800
-org.wso2.carbon.identity.application.authenticator.requestpath.oauth_5.1.2.jar  bundle         apache2   9895
-org.wso2.carbon.identity.application.authenticator.samlsso-5.1.3.jar            bundle         apache2   9799
-org.wso2.carbon.identity.application.authenticator.yahoo-5.1.2.jar              bundle         apache2   9798
-org.wso2.carbon.identity.application.common_5.2.2.jar                           bundle         apache2   9894
-org.wso2.carbon.identity.application.mgt.stub_5.2.2.jar                         bundle         apache2   9893
-org.wso2.carbon.identity.application.mgt.ui_5.2.2.jar                           bundle         apache2   9892
-org.wso2.carbon.identity.application.mgt_5.2.2.jar                              bundle         apache2   9891
-org.wso2.carbon.identity.authenticator.iwa.stub_5.1.2.jar                       bundle         apache2   9890
-org.wso2.carbon.identity.authenticator.iwa.ui_5.1.2.jar                         bundle         apache2   9889
-org.wso2.carbon.identity.authenticator.iwa_5.1.2.jar                            bundle         apache2   9888
-org.wso2.carbon.identity.authenticator.mutualssl_5.1.1.jar                      bundle         apache2   8384
-org.wso2.carbon.identity.authenticator.saml2.sso.common_5.1.4.jar               bundle         apache2   9887
-org.wso2.carbon.identity.authenticator.saml2.sso.stub_5.1.4.jar                 bundle         apache2   9886
-org.wso2.carbon.identity.authenticator.saml2.sso.ui_5.1.4.jar                   bundle         apache2   9885
-org.wso2.carbon.identity.authenticator.saml2.sso_5.1.4.jar                      bundle         apache2   9884
-org.wso2.carbon.identity.authenticator.thrift_5.2.2.jar                         bundle         apache2   9883
-org.wso2.carbon.identity.base_5.2.2.jar                                         bundle         apache2   9882
-org.wso2.carbon.identity.core.ui_5.2.2.jar                                      bundle         apache2   9881
-org.wso2.carbon.identity.core_5.2.2.jar                                         bundle         apache2   9880
-org.wso2.carbon.identity.data.publisher.application.authentication_5.1.2.jar    bundle         apache2   9879
-org.wso2.carbon.identity.entitlement.common_5.2.2.jar                           bundle         apache2   9878
-org.wso2.carbon.identity.entitlement.stub_5.2.2.jar                             bundle         apache2   9877
-org.wso2.carbon.identity.entitlement.ui_5.2.2.jar                               bundle         apache2   9876
-org.wso2.carbon.identity.entitlement_5.2.2.jar                                  bundle         apache2   9875
-org.wso2.carbon.identity.mgt.stub_5.2.2.jar                                     bundle         apache2   9874
-org.wso2.carbon.identity.mgt.ui_5.2.2.jar                                       bundle         apache2   9873
-org.wso2.carbon.identity.mgt_5.2.2.jar                                          bundle         apache2   9872
-org.wso2.carbon.identity.notification.mgt.email_5.1.1.jar                       bundle         apache2   8368
-org.wso2.carbon.identity.notification.mgt.json_5.1.1.jar                        bundle         apache2   8367
-org.wso2.carbon.identity.notification.mgt_5.2.2.jar                             bundle         apache2   9871
-org.wso2.carbon.identity.oauth.common_5.1.3.jar                                 bundle         apache2   9870
-org.wso2.carbon.identity.oauth.stub_5.1.3.jar                                   bundle         apache2   9869
-org.wso2.carbon.identity.oauth.ui_5.1.3.jar                                     bundle         apache2   9868
-org.wso2.carbon.identity.oauth_5.1.3.jar                                        bundle         apache2   9867
-org.wso2.carbon.identity.oidc.session_5.1.3.jar                                 bundle         apache2   9866
-org.wso2.carbon.identity.provider_5.1.1.jar                                     bundle         apache2   8360
-org.wso2.carbon.identity.provisioning.connector.google_5.1.1.jar                bundle         apache2   8359
-org.wso2.carbon.identity.provisioning.connector.salesforce_5.1.1.jar            bundle         apache2   8358
-org.wso2.carbon.identity.provisioning.connector.scim_5.1.1.jar                  bundle         apache2   8357
-org.wso2.carbon.identity.provisioning.connector.spml_5.1.1.jar                  bundle         apache2   8356
-org.wso2.carbon.identity.provisioning_5.2.2.jar                                 bundle         apache2   9865
-org.wso2.carbon.identity.scim.common_5.1.2.jar                                  bundle         apache2   9864
-org.wso2.carbon.identity.sso.agent_5.1.0.jar                                    bundle         apache2   8353
-org.wso2.carbon.identity.sso.saml.stub_5.1.1.jar                                bundle         apache2   8352
-org.wso2.carbon.identity.sso.saml.stub_5.1.2.jar                                bundle         apache2   9863
-org.wso2.carbon.identity.sso.saml.ui_5.1.2.jar                                  bundle         apache2   9862
-org.wso2.carbon.identity.sso.saml_5.1.2.jar                                     bundle         apache2   9861
-org.wso2.carbon.identity.sts.mgt.stub_5.1.2.jar                                 bundle         apache2   9860
-org.wso2.carbon.identity.sts.mgt.ui_5.1.2.jar                                   bundle         apache2   9859
-org.wso2.carbon.identity.sts.mgt_5.1.2.jar                                      bundle         apache2   9858
-org.wso2.carbon.identity.sts.passive.stub_5.1.2.jar                             bundle         apache2   9857
-org.wso2.carbon.identity.sts.passive.ui_5.1.2.jar                               bundle         apache2   9856
-org.wso2.carbon.identity.sts.passive_5.1.2.jar                                  bundle         apache2   9855
-org.wso2.carbon.identity.sts.store_5.1.2.jar                                    bundle         apache2   9854
-org.wso2.carbon.identity.tools.saml.validator.stub_5.1.1.jar                    bundle         apache2   8342
-org.wso2.carbon.identity.tools.saml.validator.ui_5.1.1.jar                      bundle         apache2   8341
-org.wso2.carbon.identity.tools.saml.validator_5.1.1.jar                         bundle         apache2   8340
-org.wso2.carbon.identity.user.account.association.stub_5.1.1.jar                bundle         apache2   8339
-org.wso2.carbon.identity.user.account.association_5.1.1.jar                     bundle         apache2   8338
-org.wso2.carbon.identity.user.profile.stub_5.2.2.jar                            bundle         apache2   9853
-org.wso2.carbon.identity.user.profile.ui_5.2.2.jar                              bundle         apache2   9852
-org.wso2.carbon.identity.user.profile_5.2.2.jar                                 bundle         apache2   9851
-org.wso2.carbon.identity.user.registration.stub_5.2.2.jar                       bundle         apache2   9850
-org.wso2.carbon.identity.user.registration_5.2.2.jar                            bundle         apache2   9849
-org.wso2.carbon.identity.user.store.configuration.deployer_5.2.2.jar            bundle         apache2   9848
-org.wso2.carbon.identity.user.store.configuration.stub_5.2.2.jar                bundle         apache2   9847
-org.wso2.carbon.identity.user.store.configuration.ui_5.2.2.jar                  bundle         apache2   9846
-org.wso2.carbon.identity.user.store.configuration_5.2.2.jar                     bundle         apache2   9845
-org.wso2.carbon.identity.user.store.count.stub_5.2.2.jar                        bundle         apache2   9844
-org.wso2.carbon.identity.user.store.count_5.2.2.jar                             bundle         apache2   9843
-org.wso2.carbon.identity.user.store.remote_5.1.1.jar                            bundle         apache2   8326
-org.wso2.carbon.identity.workflow.impl.stub_5.1.2.jar                           bundle         apache2   9842
-org.wso2.carbon.identity.workflow.impl.ui_5.1.2.jar                             bundle         apache2   9841
-org.wso2.carbon.identity.workflow.impl_5.1.2.jar                                bundle         apache2   9840
-org.wso2.carbon.identity.workflow.mgt.bps.stub_5.1.2.jar                        bundle         apache2   9839
-org.wso2.carbon.identity.workflow.mgt.stub_5.2.2.jar                            bundle         apache2   9838
-org.wso2.carbon.identity.workflow.mgt.ui_5.2.2.jar                              bundle         apache2   9837
-org.wso2.carbon.identity.workflow.mgt_5.2.2.jar                                 bundle         apache2   9836
-org.wso2.carbon.identity.workflow.template_5.1.1.jar                            bundle         apache2   8318
-org.wso2.carbon.idp.mgt.stub_5.2.2.jar                                          bundle         apache2   9835
-org.wso2.carbon.idp.mgt.ui_5.2.2.jar                                            bundle         apache2   9834
-org.wso2.carbon.idp.mgt_5.2.2.jar                                               bundle         apache2   9833
-org.wso2.carbon.ldap.server_5.1.1.jar                                           bundle         apache2   8314
-org.wso2.carbon.logging-4.4.9.jar                                               bundle         apache2   9546
-org.wso2.carbon.logging.admin.stub_4.5.4.jar                                    bundle         apache2   8313
-org.wso2.carbon.logging.admin.ui_4.5.4.jar                                      bundle         apache2   8312
-org.wso2.carbon.logging.service_4.5.4.jar                                       bundle         apache2   8311
-org.wso2.carbon.logging.view.stub_4.5.4.jar                                     bundle         apache2   8310
-org.wso2.carbon.logging.view.ui_4.5.4.jar                                       bundle         apache2   8309
-org.wso2.carbon.logging_4.4.9.jar                                               bundle         apache2   9576
-org.wso2.carbon.metrics.common_1.2.2.jar                                        bundle         apache2   8818
-org.wso2.carbon.metrics.das.reporter_1.2.2.jar                                  bundle         apache2   8817
-org.wso2.carbon.metrics.data.common_1.2.2.jar                                   bundle         apache2   8816
-org.wso2.carbon.metrics.data.service.stub_1.2.2.jar                             bundle         apache2   8815
-org.wso2.carbon.metrics.data.service_1.2.2.jar                                  bundle         apache2   8814
-org.wso2.carbon.metrics.impl_1.2.2.jar                                          bundle         apache2   8813
-org.wso2.carbon.metrics.jdbc.reporter_1.2.2.jar                                 bundle         apache2   8812
-org.wso2.carbon.metrics.manager_1.2.2.jar                                       bundle         apache2   8811
-org.wso2.carbon.metrics.view.ui_1.2.2.jar                                       bundle         apache2   8810
-org.wso2.carbon.mex_5.1.2.jar                                                   bundle         apache2   9832
-org.wso2.carbon.module.mgt_4.7.0.jar                                            bundle         apache2   8306
-org.wso2.carbon.ndatasource.common_4.4.9.jar                                    bundle         apache2   9575
-org.wso2.carbon.ndatasource.core_4.4.9.jar                                      bundle         apache2   9574
-org.wso2.carbon.ndatasource.rdbms_4.4.9.jar                                     bundle         apache2   9573
-org.wso2.carbon.operation.mgt_4.7.0.jar                                         bundle         apache2   8302
-org.wso2.carbon.osgi.security_4.4.9.jar                                         bundle         apache2   9572
-org.wso2.carbon.policyeditor.ui_5.2.2.jar                                       bundle         apache2   9831
-org.wso2.carbon.policyeditor_5.2.2.jar                                          bundle         apache2   9830
-org.wso2.carbon.qpid.stub_4.5.4.jar                                             bundle         apache2   8298
-org.wso2.carbon.queuing_4.4.9.jar                                               bundle         apache2   9571
-org.wso2.carbon.registry.admin.api_4.5.4.jar                                    bundle         apache2   8296
-org.wso2.carbon.registry.api_4.4.9.jar                                          bundle         apache2   9570
-org.wso2.carbon.registry.common.ui_4.5.4.jar                                    bundle         apache2   8294
-org.wso2.carbon.registry.common_4.5.4.jar                                       bundle         apache2   8293
-org.wso2.carbon.registry.core_4.4.9.jar                                         bundle         apache2   9569
-org.wso2.carbon.registry.indexing_4.5.4.jar                                     bundle         apache2   8291
-org.wso2.carbon.registry.profiles.stub_4.5.4.jar                                bundle         apache2   8290
-org.wso2.carbon.registry.profiles.ui_4.5.4.jar                                  bundle         apache2   8289
-org.wso2.carbon.registry.profiles_4.5.4.jar                                     bundle         apache2   8288
-org.wso2.carbon.registry.properties.stub_4.5.4.jar                              bundle         apache2   8287
-org.wso2.carbon.registry.properties.ui_4.5.4.jar                                bundle         apache2   8286
-org.wso2.carbon.registry.properties_4.5.4.jar                                   bundle         apache2   8285
-org.wso2.carbon.registry.resource.stub_4.5.4.jar                                bundle         apache2   8284
-org.wso2.carbon.registry.resource.ui_4.5.4.jar                                  bundle         apache2   8283
-org.wso2.carbon.registry.resource_4.5.4.jar                                     bundle         apache2   8282
-org.wso2.carbon.registry.search.stub_4.5.4.jar                                  bundle         apache2   8281
-org.wso2.carbon.registry.search.ui_4.5.4.jar                                    bundle         apache2   8280
-org.wso2.carbon.registry.search_4.5.4.jar                                       bundle         apache2   8279
-org.wso2.carbon.registry.server_4.4.9.jar                                       bundle         apache2   9568
-org.wso2.carbon.registry.servlet_4.5.4.jar                                      bundle         apache2   8277
-org.wso2.carbon.roles.mgt.stub_4.4.9.jar                                        bundle         apache2   9567
-org.wso2.carbon.roles.mgt.ui_4.4.9.jar                                          bundle         apache2   9566
-org.wso2.carbon.roles.mgt_4.4.9.jar                                             bundle         apache2   9565
-org.wso2.carbon.securevault_4.4.9.jar                                           bundle         apache2   9564
-org.wso2.carbon.security.mgt.stub_5.2.2.jar                                     bundle         apache2   9829
-org.wso2.carbon.security.mgt.ui_5.2.2.jar                                       bundle         apache2   9828
-org.wso2.carbon.security.mgt_5.2.2.jar                                          bundle         apache2   9827
-org.wso2.carbon.server-4.4.9.jar                                                bundle         apache2   9545
-org.wso2.carbon.server.admin.common_4.4.9.jar                                   bundle         apache2   9563
-org.wso2.carbon.server.admin.stub_4.4.9.jar                                     bundle         apache2   9562
-org.wso2.carbon.server.admin.ui_4.4.9.jar                                       bundle         apache2   9561
-org.wso2.carbon.server.admin_4.4.9.jar                                          bundle         apache2   9560
-org.wso2.carbon.service.mgt_4.7.0.jar                                           bundle         apache2   8265
-org.wso2.carbon.statistics.stub_4.5.4.jar                                       bundle         apache2   8264
-org.wso2.carbon.statistics.ui_4.5.4.jar                                         bundle         apache2   8263
-org.wso2.carbon.statistics_4.5.4.jar                                            bundle         apache2   8262
-org.wso2.carbon.sts.stub_5.1.2.jar                                              bundle         apache2   9826
-org.wso2.carbon.sts.ui_5.1.2.jar                                                bundle         apache2   9825
-org.wso2.carbon.sts_5.1.2.jar                                                   bundle         apache2   9824
-org.wso2.carbon.tenant.common.stub_4.5.4.jar                                    bundle         apache2   8258
-org.wso2.carbon.tenant.common_4.5.4.jar                                         bundle         apache2   8257
-org.wso2.carbon.tenant.dispatcher_4.6.0.jar                                     bundle         apache2   8518
-org.wso2.carbon.tenant.keystore.mgt_4.6.0.jar                                   bundle         apache2   8517
-org.wso2.carbon.tenant.mgt.core_4.6.0.jar                                       bundle         apache2   8516
-org.wso2.carbon.tenant.mgt.stub_4.6.0.jar                                       bundle         apache2   8515
-org.wso2.carbon.tenant.mgt.ui_4.6.0.jar                                         bundle         apache2   8514
-org.wso2.carbon.tenant.mgt_4.6.0.jar                                            bundle         apache2   8513
-org.wso2.carbon.tenant.redirector.servlet.stub_4.6.0.jar                        bundle         apache2   8512
-org.wso2.carbon.tenant.redirector.servlet.ui_4.6.0.jar                          bundle         apache2   8511
-org.wso2.carbon.tenant.redirector.servlet_4.6.0.jar                             bundle         apache2   8510
-org.wso2.carbon.tenant.sso.redirector.ui_4.6.0.jar                              bundle         apache2   8509
-org.wso2.carbon.tenant.theme.mgt_4.6.0.jar                                      bundle         apache2   8508
-org.wso2.carbon.tomcat.ext_4.4.9.jar                                            bundle         apache2   9558
-org.wso2.carbon.tomcat.patch_4.7.0.jar                                          bundle         apache2   8244
-org.wso2.carbon.tomcat_4.4.9.jar                                                bundle         apache2   9557
-org.wso2.carbon.tracer.stub_4.5.4.jar                                           bundle         apache2   8242
-org.wso2.carbon.tracer.ui_4.5.4.jar                                             bundle         apache2   8241
-org.wso2.carbon.tracer_4.5.4.jar                                                bundle         apache2   8240
-org.wso2.carbon.ui.menu.general_4.4.9.jar                                       bundle         apache2   9556
-org.wso2.carbon.ui.menu.registry_4.4.5.jar                                      bundle         apache2   7766
-org.wso2.carbon.ui.menu.tools_4.4.7.jar                                         bundle         apache2   8238
-org.wso2.carbon.ui_4.4.9.jar                                                    bundle         apache2   9555
-org.wso2.carbon.um.ws.api.stub_5.1.2.jar                                        bundle         apache2   9823
-org.wso2.carbon.um.ws.api_5.1.2.jar                                             bundle         apache2   9822
-org.wso2.carbon.um.ws.service_5.1.2.jar                                         bundle         apache2   9821
-org.wso2.carbon.unifiedendpoint.core_4.4.9.jar                                  bundle         apache2   8233
-org.wso2.carbon.user.api_4.4.9.jar                                              bundle         apache2   9554
-org.wso2.carbon.user.core_4.4.9.jar                                             bundle         apache2   9553
-org.wso2.carbon.user.mgt.common_5.2.2.jar                                       bundle         apache2   9820
-org.wso2.carbon.user.mgt.stub_5.2.2.jar                                         bundle         apache2   9819
-org.wso2.carbon.user.mgt.ui_5.2.2.jar                                           bundle         apache2   9818
-org.wso2.carbon.user.mgt.workflow.stub_5.2.2.jar                                bundle         apache2   9817
-org.wso2.carbon.user.mgt.workflow.ui_5.1.1.jar                                  bundle         apache2   8226
-org.wso2.carbon.user.mgt.workflow_5.1.1.jar                                     bundle         apache2   8225
-org.wso2.carbon.user.mgt_5.2.2.jar                                              bundle         apache2   9816
-org.wso2.carbon.utils_4.4.9.jar                                                 bundle         apache2   9552
-org.wso2.carbon.webapp.deployer_4.7.0.jar                                       bundle         apache2   8222
-org.wso2.carbon.webapp.mgt_4.7.0.jar                                            bundle         apache2   8221
-org.wso2.carbon.xfer_4.2.0.jar                                                  bundle         apache2   2254
-org.wso2.charon.core_2.0.7.jar                                                  bundle         apache2   9815
-org.wso2.ciphertool-1.0.0-wso2v3.jar                                            bundle         apache2   4038
-org.wso2.identity.styles_5.2.0.jar                                              bundle         apache2   9814
-org.wso2.orbit.asm4.asm4-all_4.0.0.wso2v1.jar                                   bundle         apache2   4710
-org.wso2.securevault_1.0.0.wso2v2.jar                                           bundle         apache2   768
-org.wso2.stratos.identity.dashboard.ui_2.2.1.jar                                bundle         apache2   2913
-patch.jar                                                                       jarinbundle    epl1      1137
-pdepublishing-ant.jar                                                           jar            epl1      524
-pdepublishing.jar                                                               jar            epl1      525
-perf4j_0.9.12.wso2v1.jar                                                        bundle         apache2   832
-poi-ooxml_3.14.0.wso2v1.jar                                                     bundle         apache2   8218
-poi-scratchpad_3.14.0.wso2v1.jar                                                bundle         apache2   8217
-poi_3.14.0.wso2v1.jar                                                           bundle         apache2   8216
-rampart-1.6.1-wso2v22.mar                                                       bundle         apache2   9910
-rampart-core_1.6.1.wso2v22.jar                                                  bundle         apache2   9813
-rampart-policy_1.6.1.wso2v22.jar                                                bundle         apache2   9812
-rampart-trust_1.6.1.wso2v22.jar                                                 bundle         apache2   9811
-rome_0.9.0.wso2v1.jar                                                           bundle         apache2   930
-saxon.bps_9.0.0.x-wso2v1.jar                                                    bundle         mpl11     985
-saxon.he_9.4.0.wso2v1.jar                                                       bundle         mpl10     1586
-scribe-1.3.1.jar                                                                jarinbundle    mit       1801
-serp_1.13.1.wso2v1.jar                                                          bundle         bsd       1574
-shared-asn1-0.9.19.jar                                                          jarinbundle    apache2   464
-shared-asn1-codec-0.9.19.jar                                                    jarinbundle    apache2   480
-shared-cursor-0.9.19.jar                                                        jarinbundle    apache2   468
-shared-dsml-parser-0.9.19.jar                                                   jarinbundle    apache2   455
-shared-i18n-0.9.19.jar                                                          jarinbundle    apache2   444
-shared-ldap-0.9.19.jar                                                          jarinbundle    apache2   443
-shared-ldap-constants-0.9.19.jar                                                jarinbundle    apache2   483
-shared-ldap-converter-0.9.19.jar                                                jarinbundle    apache2   450
-shared-ldap-jndi-0.9.19.jar                                                     jarinbundle    apache2   482
-shared-ldap-schema-0.9.19.jar                                                   jarinbundle    apache2   442
-shared-ldap-schema-dao-0.9.19.jar                                               jarinbundle    apache2   452
-shared-ldap-schema-loader-0.9.19.jar                                            jarinbundle    apache2   445
-shared-ldap-schema-manager-0.9.19.jar                                           jarinbundle    apache2   460
-shared-ldif-0.9.19.jar                                                          jarinbundle    apache2   458
-siddhi-core_3.1.1.jar                                                           bundle         apache2   1899
-slf4j.api_1.6.1.jar                                                             bundle         mit       354
-slf4j.api_1.7.13.jar                                                            bundle         mit       1606
-slf4j.api_1.7.21.jar                                                            bundle         mit       1852
-slf4j.log4j12_1.6.1.jar                                                         bundle         mit       346
-slf4j.log4j12_1.7.13.jar                                                        bundle         mit       1605
-slf4j.log4j12_1.7.21.jar                                                        bundle         mit       1851
-soa.model.core_1.5.0.wso2v4.jar                                                 bundle         apache2   7087
-solr_5.2.1.wso2v1.jar                                                           bundle         apache2   4384
-spatial4j_0.4.1.wso2v1.jar                                                      bundle         apache2   4045
-spring-aop-3.0.7.RELEASE.jar                                                    bundle         apache2   279
-spring-asm-3.0.7.RELEASE.jar                                                    bundle         apache2   261
-spring-beans-3.0.7.RELEASE.jar                                                  bundle         apache2   275
-spring-context-3.0.7.RELEASE.jar                                                bundle         apache2   273
-spring-core-3.0.7.RELEASE.jar                                                   bundle         apache2   270
-spring-expression-3.0.7.RELEASE.jar                                             bundle         apache2   272
-spring-web-3.0.7.RELEASE.jar                                                    bundle         apache2   268
-spring.framework_3.2.9.wso2v1.jar                                               bundle         apache2   4044
-stax2-api-3.1.4.jar                                                             bundle         bsd       1089
-step2-common-1.0.0-wso2v2.jar                                                   bundle         apache2   2909
-step2-consumer-1.0.0-wso2v2.jar                                                 bundle         apache2   2908
-step2_1.0.0.wso2v2.jar                                                          bundle         apache2   2907
-svn-client-adapter_1.10.9.wso2v1.jar                                            bundle         apache2   4043
-tcpmon-1.0.jar                                                                  jar            bsd       255
-tiles-jsp_2.0.5.wso2v1.jar                                                      bundle         apache2   989
-tomcat-annotations-api-7.0.70.jar                                               jar            apache2   1958
-tomcat-catalina-ha_7.0.70.wso2v1.jar                                            bundle         apache2   9551
-tomcat-el-api_7.0.70.wso2v1.jar                                                 bundle         apache2   9550
-tomcat-jsp-api_7.0.70.wso2v1.jar                                                bundle         apache2   9549
-tomcat-juli-7.0.70.jar                                                          jar            apache2   1957
-tomcat-servlet-api_7.0.70.wso2v1.jar                                            bundle         apache2   9548
-tomcat_7.0.70.wso2v1.jar                                                        bundle         apache2   9547
-tranql-connector_1.1.0.wso2v1.jar                                               bundle         apache2   2855
-tyrus-standalone-client_1.7.0.wso2v1.jar                                        bundle         cddl+gpl  4226
-u2flib-server-core-0.14.0.jar                                                   jarinbundle    bsd       1549
-velocity-1.7.jar                                                                bundle         apache2   509
-waffle-jna_1.6.0.wso2v5.jar                                                     bundle         epl1      8207
-woden_1.0.0.M9-wso2v1.jar                                                       bundle         apache2   3755
-woodstox-core-asl-4.4.1.jar                                                     bundle         apache2   1087
-wsdl4j-1.6.3.jar                                                                jar            cpl1      276
-wsdl4j_1.6.2.wso2v4.jar                                                         bundle         apache2   745
-wso2-uri-templates_1.6.2.jar                                                    bundle         apache2   364
-wss4j_1.5.11.wso2v15.jar                                                        bundle         apache2   9810
-xalan-2.7.2.wso2v2.jar                                                          bundle         apache2   8202
-xercesImpl-2.8.1.wso2v2.jar                                                     bundle         apache2   663
-xml-apis-1.4.01.jar                                                             jar            apache2   1793
-xml-resolver-1.2.jar                                                            jar            apache2   278
-xmlbeans-2.3.0.jar                                                              jarinbundle    apache2   344
-xmlbeans_2.3.0.wso2v1.jar                                                       bundle         apache2   749
-xmlschema-core-2.1.0.jar                                                        bundle         apache2   1145
-XmlSchema_1.4.7.wso2v3.jar                                                      bundle         apache2   3585
-xmlsec-1.5.8.jar                                                                bundle         apache2   1144
+abdera_1.0.0.wso2v3.jar                                                         bundle         apache2
+activation-1.1.jar                                                              jarinbundle    cddl1
+addressing-1.6.1-wso2v20.mar                                                    bundle         apache2
+ajaxtags_1.3.0.beta-rc7-wso2v1.jar                                              bundle         apache2
+annogen_0.1.0.wso2v1.jar                                                        bundle         apache2
+ant-contrib-1.0b3.jar                                                           jar            apache2
+antlr-runtime_3.2.0.wso2v1.jar                                                  bundle         bsd
+antlr_3.2.0.wso2v1.jar                                                          bundle         bsd
+ant_1.7.0.wso2v1.jar                                                            bundle         apache2
+aopalliance-1.0.jar                                                             jar            apache2
+apache-zookeeper_3.3.4.wso2v1.jar                                               bundle         apache2
+apacheds-avl-partition-1.5.7.jar                                                jarinbundle    apache2
+apacheds-core-1.5.7.jar                                                         jarinbundle    apache2
+apacheds-core-annotations-1.5.7.jar                                             jarinbundle    apache2
+apacheds-core-api-1.5.7.jar                                                     jarinbundle    apache2
+apacheds-core-avl-1.5.7.jar                                                     jarinbundle    apache2
+apacheds-core-constants-1.5.7.jar                                               jarinbundle    apache2
+apacheds-core-entry-1.5.7.jar                                                   jarinbundle    apache2
+apacheds-core-jndi-1.5.7.jar                                                    jarinbundle    apache2
+apacheds-i18n-1.5.7.jar                                                         jarinbundle    apache2
+apacheds-interceptor-kerberos-1.5.7.jar                                         jarinbundle    apache2
+apacheds-jdbm-1.5.7.jar                                                         jarinbundle    apache2
+apacheds-jdbm-partition-1.5.7.jar                                               jarinbundle    apache2
+apacheds-jdbm-store-1.5.7.jar                                                   jarinbundle    apache2
+apacheds-kerberos-shared-1.5.7.jar                                              jarinbundle    apache2
+apacheds-ldif-partition-1.5.7.jar                                               jarinbundle    apache2
+apacheds-protocol-changepw-1.5.7.jar                                            jarinbundle    apache2
+apacheds-protocol-dhcp-1.5.7.jar                                                jarinbundle    apache2
+apacheds-protocol-dns-1.5.7.jar                                                 jarinbundle    apache2
+apacheds-protocol-kerberos-1.5.7.jar                                            jarinbundle    apache2
+apacheds-protocol-ldap-1.5.7.jar                                                jarinbundle    apache2
+apacheds-protocol-ntp-1.5.7.jar                                                 jarinbundle    apache2
+apacheds-protocol-shared-1.5.7.jar                                              jarinbundle    apache2
+apacheds-server-annotations-1.5.7.jar                                           jarinbundle    apache2
+apacheds-server-jndi-1.5.7.jar                                                  jarinbundle    apache2
+apacheds-server-replication-1.5.7.jar                                           jarinbundle    apache2
+apacheds-utils-1.5.7.jar                                                        jarinbundle    apache2
+apacheds-xdbm-base-1.5.7.jar                                                    jarinbundle    apache2
+apacheds-xdbm-search-1.5.7.jar                                                  jarinbundle    apache2
+apacheds-xdbm-tools-1.5.7.jar                                                   jarinbundle    apache2
+apacheds_1.5.7.wso2v4.jar                                                       bundle         apache2
+asm-3.3.1.jar                                                                   jar            bsd
+asm_1.5.3.wso2v1.jar                                                            bundle         bsd
+asm_3.1.0.wso2v1.jar                                                            bundle         bsd
+axiom_1.2.11.wso2v11.jar                                                        bundle         apache2
+axion_1.0.0.M3-dev-wso2v1.jar                                                   bundle         apache2
+axis2-jaxbri_1.6.1.wso2v11.jar                                                  bundle         apache2
+axis2-jaxbri_1.6.1.wso2v19.jar                                                  bundle         apache2
+axis2-jibx_1.6.1.wso2v11.jar                                                    bundle         apache2
+axis2-json_1.6.1.wso2v20.jar                                                    bundle         apache2
+axis2-transport-mail_1.1.0.wso2v13.jar                                          bundle         apache2
+axis2_1.6.1.wso2v20.jar                                                         bundle         apache2
+backport-util-concurrent_3.1.0.wso2v1.jar                                       bundle         apache2
+bcel_5.2.0.wso2v1.jar                                                           bundle         apache2
+bcprov-jdk14-138.jar                                                            jarinbundle    bouncy
+bcprov-jdk15-132.jar                                                            jar            bouncy
+bcprov-jdk15on-1.52.jar                                                         jarinbundle    bouncy
+bcprov-jdk15on_1.52.0.wso2v1.jar                                                bundle         bouncy
+cassandra-thrift_1.2.13.wso2v4.jar                                              bundle         apache2
+cglib_2.2.0.wso2v1.jar                                                          bundle         apache2
+com.google.gson_2.3.1.jar                                                       bundle         apache2
+com.google.gson_2.7.0.jar                                                       bundle         apache2
+com.google.guava_15.0.0.jar                                                     bundle         apache2
+com.google.guava_19.0.0.jar                                                     bundle         apache2
+commons-beanutils-1.7.0.jar                                                     jarinbundle    apache2
+commons-cli_1.2.0.wso2v1.jar                                                    bundle         apache2
+commons-codec_1.4.0.wso2v1.jar                                                  bundle         apache2
+commons-collections-3.2.1.jar                                                   bundle         apache2
+commons-collections_3.2.2.wso2v1.jar                                            bundle         apache2
+commons-configuration_1.6.0.wso2v1.jar                                          bundle         apache2
+commons-dbcp_1.4.0.wso2v1.jar                                                   bundle         apache2
+commons-digester-1.8.jar                                                        jarinbundle    apache2
+commons-fileupload_1.3.2.wso2v1.jar                                             bundle         apache2
+commons-httpclient_3.1.0.wso2v3.jar                                             bundle         apache2
+commons-io_2.4.0.wso2v1.jar                                                     bundle         apache2
+commons-lang-2.6.0.wso2v1.jar                                                   bundle         apache2
+commons-lang-2.6.jar                                                            bundle         apache2
+commons-lang_2.6.0.wso2v1.jar                                                   bundle         apache2
+commons-logging-1.1.1.jar                                                       jar            apache2
+commons-pool_1.5.6.wso2v1.jar                                                   bundle         apache2
+commons-primitives_1.0.0.wso2v1.jar                                             bundle         apache2
+compass_2.0.1.wso2v2.jar                                                        bundle         apache2
+cors-filter_1.7.0.wso2v1.jar                                                    bundle         apache2
+csrfguard_3.1.0.wso2v2.jar                                                      bundle         bsd
+cxf-bundle-2.7.16.jar                                                           bundle         apache2
+cxf-xjc-boolean-3.0.2.jar                                                       jar            apache2
+cxf-xjc-bug671-3.0.2.jar                                                        jar            apache2
+cxf-xjc-dv-3.0.2.jar                                                            jar            apache2
+cxf-xjc-runtime-3.0.2.jar                                                       bundle         apache2
+cxf-xjc-ts-3.0.2.jar                                                            jar            apache2
+derby-10.4.1.3.jar                                                              jarinbundle    apache2
+derbytools-10.4.1.3.jar                                                         jarinbundle    apache2
+disruptor_3.3.2.wso2v2.jar                                                      bundle         apache2
+ehcache-core-2.5.1.jar                                                          jar            apache2
+ehcache_1.5.0.wso2v3.jar                                                        bundle         apache2
+encoder_1.2.0.wso2v1.jar                                                        bundle         apache2
+gdata-core_1.47.0.wso2v1.jar                                                    bundle         apache2
+geronimo-connector_2.0.1.wso2v1.jar                                             bundle         apache2
+geronimo-j2ee-connector_1.5_spec_1.0.0.wso2v1.jar                               bundle         apache2
+geronimo-jaxws_2.2_spec-1.0.jar                                                 bundle         apache2
+geronimo-jms_1.1_spec-1.1.0.wso2v1.jar                                          bundle         apache2
+geronimo-jta_1.1_spec-1.1.jar                                                   jar            apache2
+geronimo-kernel_2.0.1.wso2v1.jar                                                bundle         apache2
+geronimo-saaj_1.3_spec_1.0.0.wso2v3.jar                                         bundle         apache2
+geronimo-spec-javamail_1.3.0.rc51-wso2v1.jar                                    bundle         apache2
+geronimo-spec-jms_1.1.0.rc4-wso2v1.jar                                          bundle         apache2
+geronimo-transaction_2.0.1.wso2v1.jar                                           bundle         apache2
+google-api-client-1.17.0-rc.jar                                                 jarinbundle    apache2
+google-api-services-admin-directory_v1-rev28-1.17.0-rc.jar                      jarinbundle    apache2
+google-http-client-1.17.0-rc.jar                                                jarinbundle    apache2
+google-http-client-jackson2-1.17.0-rc.jar                                       jarinbundle    apache2
+google-oauth-client-1.17.0-rc.jar                                               jarinbundle    apache2
+groovy-all_2.3.9.jar                                                            bundle         apache2
+guava-15.0.jar                                                                  jarinbundle    apache2
+guice_3.0.0.wso2v1.jar                                                          bundle         apache2
+hashids-1.0.1.jar                                                               jar            mit
+h2-1.3.175.jar                                                                  jarinbundle    epl1
+h2_1.3.175.wso2v1.jar                                                           bundle         apache2
+hazelcast_3.5.4.wso2v2.jar                                                      bundle         apache2
+hector-core_1.1.4.wso2v1.jar                                                    bundle         apache2
+hibernate_3.2.5.ga-wso2v1.jar                                                   bundle         lgpl2
+high-scale-lib_1.0.0.wso2v1.jar                                                 bundle         apache2
+hsqldb_1.8.0.7wso2v1.jar                                                        bundle         bsd
+httpasyncclient-4.0-beta3.jar                                                   jar            apache2
+httpclient-4.2.5.jar                                                            jar            apache2
+httpclient_4.3.1.wso2v2.jar                                                     bundle         apache2
+httpcore-4.2.4.jar                                                              jar            apache2
+httpcore-nio-4.2.4.jar                                                          jar            apache2
+httpcore_4.3.3.wso2v1.jar                                                       bundle         apache2
+httpmime_4.3.1.wso2v2.jar                                                       bundle         apache2
+io.dropwizard.metrics.core_3.1.2.jar                                            bundle         apache2
+io.dropwizard.metrics.jvm_3.1.2.jar                                             bundle         apache2
+jackson-annotations-2.5.0.jar                                                   jarinbundle    apache2
+jackson-core-2.1.3.jar                                                          jarinbundle    apache2
+jackson-core-2.5.0.jar                                                          jarinbundle    apache2
+jackson-databind-2.5.0.jar                                                      jarinbundle    apache2
+java-property-utils_1.9.0.wso2v1.jar                                            bundle         apache2
+javasysmon_0.3.3.wso2v1.jar                                                     bundle         bsd
+javax.cache.wso2_4.4.9.jar                                                      bundle         cddl+gpl
+javax.ws.rs-api-2.0-m10.jar                                                     bundle         cddl+gpl
+jaxb-impl-2.2.6.jar                                                             jar            cddl1
+jaxb-xjc-2.2.6.jar                                                              jar            cddl1
+jaxb_2.2.5.wso2v1.jar                                                           bundle         cddl1
+jdbc-pool_7.0.34.wso2v2.jar                                                     bundle         apache2
+jdom_1.0.0.wso2v1.jar                                                           bundle         apache2
+jericho-html-2.4.jar                                                            jarinbundle    epl1
+jettison-1.3.4.jar                                                              bundle         apache2
+jettison_1.3.4.wso2v1.jar                                                       bundle         apache2
+jibx_1.2.1.wso2v1.jar                                                           bundle         apache2
+joda-time_2.8.2.wso2v1.jar                                                      bundle         apache2
+json-simple_1.1.0.wso2v1.jar                                                    bundle         apache2
+json_1.0.0.wso2v1.jar                                                           bundle         apache2
+json_2.0.0.wso2v1.jar                                                           bundle         apache2
+json_3.0.0.wso2v1.jar                                                           bundle         apache2
+jsr305-1.3.9.jar                                                                jarinbundle    apache2
+jstl_1.2.1.wso2v2.jar                                                           bundle         cddl1
+js_1.7.0.R4wso2v1.jar                                                           bundle         mpl10
+kaptcha_2.3.0.wso2v1.jar                                                        bundle         apache2
+libthrift_0.7.0.wso2v2.jar                                                      bundle         apache2
+libthrift_0.8.0.wso2v1.jar                                                      bundle         apache2
+libthrift_0.9.2.wso2v1.jar                                                      bundle         apache2
+lucene_5.2.1.wso2v1.jar                                                         bundle         apache2
+mail-1.4.jar                                                                    jarinbundle    cddl1
+mina-core-2.0.0-RC1.jar                                                         jarinbundle    apache2
+neethi-3.0.3.jar                                                                bundle         apache2
+neethi_2.0.4.wso2v5.jar                                                         bundle         apache2
+nekohtml-1.9.10.jar                                                             jarinbundle    apache2
+net.minidev.json-smart_1.3.0.jar                                                bundle         apache2
+nimbus-jose-jwt_2.26.1.wso2v3.jar                                               bundle         apache2
+noggit_0.6.0.wso2v1.jar                                                         bundle         apache2
+ode-agents-1.3.5-wso2v16.jar                                                    bundle         apache2
+ode-axis2-1.3.5-wso2v16.jar                                                     bundle         apache2
+ode-bpel-api-1.3.5-wso2v16.jar                                                  bundle         apache2
+ode-bpel-api-jca-1.3.5-wso2v16.jar                                              bundle         apache2
+ode-bpel-compiler-1.3.5-wso2v16.jar                                             bundle         apache2
+ode-bpel-connector-1.3.5-wso2v16.jar                                            bundle         apache2
+ode-bpel-dao-1.3.5-wso2v16.jar                                                  bundle         apache2
+ode-bpel-epr-1.3.5-wso2v16.jar                                                  bundle         apache2
+ode-bpel-extensions-e4x-1.3.5-wso2v16.jar                                       bundle         apache2
+ode-bpel-extensions-long-running-1.3.5-wso2v16.jar                              bundle         apache2
+ode-bpel-obj-1.3.5-wso2v16.jar                                                  bundle         apache2
+ode-bpel-ql-1.3.5-wso2v16.jar                                                   bundle         apache2
+ode-bpel-runtime-1.3.5-wso2v16.jar                                              bundle         apache2
+ode-bpel-schemas-1.3.5-wso2v16.jar                                              bundle         apache2
+ode-bpel-store-1.3.5-wso2v16.jar                                                bundle         apache2
+ode-dao-hibernate-1.3.5-wso2v16.jar                                             bundle         apache2
+ode-dao-hibernate-db-1.3.5-wso2v16.jar                                          bundle         apache2
+ode-dao-jpa-1.3.5-wso2v16.jar                                                   bundle         apache2
+ode-jacob-1.3.5-wso2v16.jar                                                     bundle         apache2
+ode-jca-ra-1.3.5-wso2v16.jar                                                    bundle         apache2
+ode-jca-server-1.3.5-wso2v16.jar                                                bundle         apache2
+ode-scheduler-simple-1.3.5-wso2v16.jar                                          bundle         apache2
+ode-utils-1.3.5-wso2v16.jar                                                     bundle         apache2
+ode_1.3.5.wso2v16.jar                                                           bundle         apache2
+oltu_1.0.0.wso2v3.jar                                                           bundle         apache2
+opencsv-1.8.jar                                                                 jarinbundle    apache2
+opencsv_1.8.0.wso2v1.jar                                                        bundle         apache2
+openid4java_1.0.0.wso2v2.jar                                                    bundle         apache2
+opensaml_2.6.4.wso2v3.jar                                                       bundle         apache2
+openspml2-192-20100413.jar                                                      jarinbundle    apache2
+openxri-client-1.2.0.jar                                                        jarinbundle    apache2
+openxri-syntax-1.2.0.jar                                                        jarinbundle    apache2
+org.apache.felix.gogo.command_0.10.0.v201209301215.jar                          bundle         apache2
+org.apache.felix.gogo.runtime_0.10.0.v201209301036.jar                          bundle         apache2
+org.apache.felix.gogo.shell_0.10.0.v201212101605.jar                            bundle         apache2
+org.apache.geronimo.specs.geronimo-jpa_2.0_spec_1.1.0.jar                       bundle         apache2
+org.apache.openjpa_2.2.0.wso2v1.jar                                             bundle         apache2
+org.apache.servicemix.bundles.jaxb-api-2.0_4.0.0.m1.jar                         bundle         apache2
+org.eclipse.core.contenttype_3.4.200.v20130326-1255.jar                         bundle         epl1
+org.eclipse.core.expressions_3.4.500.v20130515-1343.jar                         bundle         epl1
+org.eclipse.core.jobs_3.5.300.v20130429-1813.jar                                bundle         epl1
+org.eclipse.core.runtime_3.9.0.v20130326-1255.jar                               bundle         epl1
+org.eclipse.ecf.filetransfer_5.0.0.v20130604-1622.jar                           bundle         epl1
+org.eclipse.ecf.identity_3.2.0.v20130604-1622.jar                               bundle         epl1
+org.eclipse.ecf.provider.filetransfer.httpclient_4.0.200.v20120319-0616.jar     bundle         epl1
+org.eclipse.ecf.provider.filetransfer_3.2.0.v20130604-1622.jar                  bundle         epl1
+org.eclipse.ecf_3.2.0.v20130604-1622.jar                                        bundle         epl1
+org.eclipse.equinox.app_1.3.100.v20130327-1442.jar                              bundle         epl1
+org.eclipse.equinox.common_3.6.200.v20130402-1505.jar                           bundle         epl1
+org.eclipse.equinox.concurrent_1.1.0.v20130327-1442.jar                         bundle         epl1
+org.eclipse.equinox.console_1.0.100.v20130429-0953.jar                          bundle         epl1
+org.eclipse.equinox.ds_1.4.101.v20130813-1853.jar                               bundle         epl1
+org.eclipse.equinox.frameworkadmin.equinox_1.0.500.v20130327-2119.jar           bundle         epl1
+org.eclipse.equinox.frameworkadmin_2.0.100.v20130327-2119.jar                   bundle         epl1
+org.eclipse.equinox.http.helper_1.1.0.wso2v1.jar                                bundle         epl1
+org.eclipse.equinox.http.servlet_1.1.400.v20130418-1354.jar                     bundle         epl1
+org.eclipse.equinox.jsp.jasper_1.0.400.v20120522-2049.jar                       bundle         epl1
+org.eclipse.equinox.launcher_1.3.0.v20130327-1440.jar                           bundle         epl1
+org.eclipse.equinox.p2.artifact.repository_1.1.100.v20110519.jar                bundle         epl1
+org.eclipse.equinox.p2.console_1.0.300.v20130327-2119.jar                       bundle         epl1
+org.eclipse.equinox.p2.core_2.3.0.v20130327-2119.jar                            bundle         epl1
+org.eclipse.equinox.p2.director.app_1.0.300.v20130819-1621.jar                  bundle         epl1
+org.eclipse.equinox.p2.directorywatcher_1.0.300.v20130327-2119.jar              bundle         epl1
+org.eclipse.equinox.p2.director_2.3.0.v20130526-0335.jar                        bundle         epl1
+org.eclipse.equinox.p2.engine_2.3.0.v20130526-2122-wso2v1.jar                   bundle         epl1
+org.eclipse.equinox.p2.extensionlocation_1.2.100.v20130327-2119.jar             bundle         epl1
+org.eclipse.equinox.p2.garbagecollector_1.0.200.v20130327-2119.jar              bundle         epl1
+org.eclipse.equinox.p2.jarprocessor_1.0.300.v20130327-2119.jar                  bundle         epl1
+org.eclipse.equinox.p2.metadata.repository_1.2.100.v20130327-2119.jar           bundle         epl1
+org.eclipse.equinox.p2.metadata_2.2.0.v20130523-1557.jar                        bundle         epl1
+org.eclipse.equinox.p2.publisher_1.2.0.v20110511.jar                            bundle         epl1
+org.eclipse.equinox.p2.repository.tools_2.1.0.v20130327-2119.jar                bundle         epl1
+org.eclipse.equinox.p2.repository_2.3.0.v20130412-2032.jar                      bundle         epl1
+org.eclipse.equinox.p2.touchpoint.eclipse_2.1.0.v20110511-wso2v1.jar            bundle         epl1
+org.eclipse.equinox.p2.touchpoint.natives_1.1.100.v20130327-2119.jar            bundle         epl1
+org.eclipse.equinox.p2.transport.ecf_1.0.100.v20110902-0807.jar                 bundle         epl1
+org.eclipse.equinox.p2.updatechecker_1.1.200.v20130327-2119.jar                 bundle         epl1
+org.eclipse.equinox.p2.updatesite_1.0.400.v20130515-2028.jar                    bundle         epl1
+org.eclipse.equinox.preferences_3.5.100.v20130422-1538.jar                      bundle         epl1
+org.eclipse.equinox.registry_3.5.301.v20130717-1549.jar                         bundle         epl1
+org.eclipse.equinox.security_1.2.0.v20130424-1801.jar                           bundle         epl1
+org.eclipse.equinox.simpleconfigurator.manipulator_2.0.0.v20130327-2119.jar     bundle         epl1
+org.eclipse.equinox.simpleconfigurator_1.0.400.v20130327-2119.jar               bundle         epl1
+org.eclipse.equinox.util_1.0.500.v20130404-1337.jar                             bundle         epl1
+org.eclipse.jdt.core.compiler.batch_3.10.2.v20150120-1634.jar                   bundle         epl1
+org.eclipse.osgi.services_3.3.100.v20130513-1956.jar                            bundle         epl1
+org.eclipse.osgi_3.9.1.v20130814-1242.jar                                       bundle         epl1
+org.eclipse.wst.jsdt.debug.rhino.debugger_1.0.300.v201109150503.jar             bundle         epl1
+org.eclipse.wst.jsdt.debug.transport_1.0.100.v201109150330.jar                  bundle         epl1
+org.jaggeryjs.hostobjects.db_0.12.6.jar                                         bundle         apache2
+org.jaggeryjs.hostobjects.feed_0.12.6.jar                                       bundle         apache2
+org.jaggeryjs.hostobjects.file_0.12.6.jar                                       bundle         apache2
+org.jaggeryjs.hostobjects.jaggeryparser_0.12.6.jar                              bundle         apache2
+org.jaggeryjs.hostobjects.log_0.12.6.jar                                        bundle         apache2
+org.jaggeryjs.hostobjects.registry_0.12.6.jar                                   bundle         apache2
+org.jaggeryjs.hostobjects.stream_0.12.6.jar                                     bundle         apache2
+org.jaggeryjs.hostobjects.uri_0.12.6.jar                                        bundle         apache2
+org.jaggeryjs.hostobjects.web_0.12.6.jar                                        bundle         apache2
+org.jaggeryjs.hostobjects.xhr_0.12.6.jar                                        bundle         apache2
+org.jaggeryjs.hostobjects.xslt_0.12.6.jar                                       bundle         apache2
+org.jaggeryjs.jaggery.app.mgt_0.12.6.jar                                        bundle         apache2
+org.jaggeryjs.jaggery.core_0.12.6.jar                                           bundle         apache2
+org.jaggeryjs.jaggery.deployer_0.12.6.jar                                       bundle         apache2
+org.jaggeryjs.jaggery.tools_0.12.6.jar                                          bundle         apache2
+org.jaggeryjs.modules.email_1.5.3.jar                                           bundle         apache2
+org.jaggeryjs.modules.oauth_1.5.3.jar                                           bundle         apache2
+org.jaggeryjs.modules.process_1.5.3.jar                                         bundle         apache2
+org.jaggeryjs.modules.sso_1.5.3.jar                                             bundle         apache2
+org.jaggeryjs.modules.uuid_1.5.3.jar                                            bundle         apache2
+org.jaggeryjs.modules.ws_1.5.3.jar                                              bundle         apache2
+org.jaggeryjs.scriptengine_0.12.6.jar                                           bundle         apache2
+org.restlet_2.3.0.wso2v1.jar                                                    bundle         apache2
+org.sat4j.core_2.3.5.v201308161310.jar                                          bundle         epl1+lgpl
+org.sat4j.pb_2.3.5.v201308161310.jar                                            bundle         epl1+lgpl
+org.wso2.balana.utils_1.0.5.jar                                                 bundle         apache2
+org.wso2.balana_1.0.5.jar                                                       bundle         apache2
+org.wso2.carbon.addressing_4.4.9.jar                                            bundle         apache2
+org.wso2.carbon.application.deployer_4.4.9.jar                                  bundle         apache2
+org.wso2.carbon.application.upload_4.5.4.jar                                    bundle         apache2
+org.wso2.carbon.attachment.mgt.skeleton_4.4.9.jar                               bundle         apache2
+org.wso2.carbon.attachment.mgt_4.4.9.jar                                        bundle         apache2
+org.wso2.carbon.authenticator.proxy_4.4.9.jar                                   bundle         apache2
+org.wso2.carbon.authenticator.stub_4.4.9.jar                                    bundle         apache2
+org.wso2.carbon.base_4.4.9.jar                                                  bundle         apache2
+org.wso2.carbon.bootstrap-4.4.9.jar                                             bundle         apache2
+org.wso2.carbon.bpel.b4p_4.4.9.jar                                              bundle         apache2
+org.wso2.carbon.bpel.cluster.notifier_4.4.9.jar                                 bundle         apache2
+org.wso2.carbon.bpel.common_4.4.9.jar                                           bundle         apache2
+org.wso2.carbon.bpel.deployer_4.4.9.jar                                         bundle         apache2
+org.wso2.carbon.bpel.skeleton_4.4.9.jar                                         bundle         apache2
+org.wso2.carbon.bpel_4.4.9.jar                                                  bundle         apache2
+org.wso2.carbon.captcha.mgt_4.2.0.jar                                           bundle         apache2
+org.wso2.carbon.captcha.mgt_4.5.2.jar                                           bundle         apache2
+org.wso2.carbon.claim.mgt.stub_5.2.2.jar                                        bundle         apache2
+org.wso2.carbon.claim.mgt.ui_5.2.2.jar                                          bundle         apache2
+org.wso2.carbon.claim.mgt_5.2.2.jar                                             bundle         apache2
+org.wso2.carbon.cluster.mgt.core_4.4.9.jar                                      bundle         apache2
+org.wso2.carbon.core.bootup.validator_4.4.9.jar                                 bundle         apache2
+org.wso2.carbon.core.commons.stub_4.4.9.jar                                     bundle         apache2
+org.wso2.carbon.core.common_4.4.9.jar                                           bundle         apache2
+org.wso2.carbon.core.services_4.4.9.jar                                         bundle         apache2
+org.wso2.carbon.core_4.4.9.jar                                                  bundle         apache2
+org.wso2.carbon.cxf.ext-4.7.0.jar                                               bundle         apache2
+org.wso2.carbon.databridge.agent_5.1.1.jar                                      bundle         apache2
+org.wso2.carbon.databridge.commons.binary_5.1.1.jar                             bundle         apache2
+org.wso2.carbon.databridge.commons.thrift_5.1.1.jar                             bundle         apache2
+org.wso2.carbon.databridge.commons_5.1.1.jar                                    bundle         apache2
+org.wso2.carbon.deployment.synchronizer.subversion_4.5.4.jar                    bundle         apache2
+org.wso2.carbon.deployment.synchronizer_4.5.4.jar                               bundle         apache2
+org.wso2.carbon.directory.server.manager.common_5.2.2.jar                       bundle         apache2
+org.wso2.carbon.directory.server.manager.stub_5.2.2.jar                         bundle         apache2
+org.wso2.carbon.directory.server.manager.ui_5.2.2.jar                           bundle         apache2
+org.wso2.carbon.directory.server.manager_5.2.2.jar                              bundle         apache2
+org.wso2.carbon.discovery.cxf_4.7.0.jar                                         bundle         apache2
+org.wso2.carbon.event.admin_4.5.4.jar                                           bundle         apache2
+org.wso2.carbon.event.application.deployer_5.1.1.jar                            bundle         apache2
+org.wso2.carbon.event.client.stub_4.5.4.jar                                     bundle         apache2
+org.wso2.carbon.event.client_4.5.4.jar                                          bundle         apache2
+org.wso2.carbon.event.common_4.5.4.jar                                          bundle         apache2
+org.wso2.carbon.event.core_4.5.4.jar                                            bundle         apache2
+org.wso2.carbon.event.output.adapter.cassandra_5.1.1.jar                        bundle         apache2
+org.wso2.carbon.event.output.adapter.core_5.1.1.jar                             bundle         apache2
+org.wso2.carbon.event.output.adapter.email_5.1.1.jar                            bundle         apache2
+org.wso2.carbon.event.output.adapter.http_5.1.1.jar                             bundle         apache2
+org.wso2.carbon.event.output.adapter.jms_5.1.1.jar                              bundle         apache2
+org.wso2.carbon.event.output.adapter.kafka_5.1.1.jar                            bundle         apache2
+org.wso2.carbon.event.output.adapter.logger_5.1.1.jar                           bundle         apache2
+org.wso2.carbon.event.output.adapter.mqtt_5.1.1.jar                             bundle         apache2
+org.wso2.carbon.event.output.adapter.rdbms_5.1.1.jar                            bundle         apache2
+org.wso2.carbon.event.output.adapter.sms_5.1.1.jar                              bundle         apache2
+org.wso2.carbon.event.output.adapter.soap_5.1.1.jar                             bundle         apache2
+org.wso2.carbon.event.output.adapter.ui_5.1.1.jar                               bundle         apache2
+org.wso2.carbon.event.output.adapter.websocket.local_5.1.1.jar                  bundle         apache2
+org.wso2.carbon.event.output.adapter.websocket_5.1.1.jar                        bundle         apache2
+org.wso2.carbon.event.output.adapter.wso2event_5.1.1.jar                        bundle         apache2
+org.wso2.carbon.event.processor.manager.commons_5.1.1.jar                       bundle         apache2
+org.wso2.carbon.event.processor.manager.core_5.1.1.jar                          bundle         apache2
+org.wso2.carbon.event.publisher.admin_5.1.1.jar                                 bundle         apache2
+org.wso2.carbon.event.publisher.core_5.1.1.jar                                  bundle         apache2
+org.wso2.carbon.event.stream.admin_5.1.1.jar                                    bundle         apache2
+org.wso2.carbon.event.stream.core_5.1.1.jar                                     bundle         apache2
+org.wso2.carbon.event.ws_4.5.4.jar                                              bundle         apache2
+org.wso2.carbon.extension.identity.authenticator.emailotp.connector-2.0.2.jar   bundle         apache2
+org.wso2.carbon.extension.identity.authenticator.office365.connector-1.0.0.jar  bundle         apache2
+org.wso2.carbon.extension.identity.authenticator.smsotp.connector-2.0.4.jar     bundle         apache2
+org.wso2.carbon.extension.identity.authenticator.totp.connector-2.0.1.jar       bundle         apache2
+org.wso2.carbon.extension.identity.authenticator.twitter.connector-1.0.5.jar    bundle         apache2
+org.wso2.carbon.feature.mgt.core_4.4.9.jar                                      bundle         apache2
+org.wso2.carbon.feature.mgt.services_4.4.9.jar                                  bundle         apache2
+org.wso2.carbon.feature.mgt.stub_4.4.9.jar                                      bundle         apache2
+org.wso2.carbon.feature.mgt.ui_4.4.9.jar                                        bundle         apache2
+org.wso2.carbon.framework.exporter_4.4.9.jar                                    bundle         apache2
+org.wso2.carbon.humantask.cleanup.scheduler_4.4.9.jar                           bundle         apache2
+org.wso2.carbon.humantask.coordination.module_4.4.9.jar                         bundle         apache2
+org.wso2.carbon.humantask.deployer_4.4.9.jar                                    bundle         apache2
+org.wso2.carbon.humantask.skeleton_4.4.9.jar                                    bundle         apache2
+org.wso2.carbon.humantask_4.4.9.jar                                             bundle         apache2
+org.wso2.carbon.i18n_4.4.9.jar                                                  bundle         apache2
+org.wso2.carbon.identity.application.authentication.endpoint.util_5.2.2.jar     bundle         apache2
+org.wso2.carbon.identity.application.authentication.framework_5.2.2.jar         bundle         apache2
+org.wso2.carbon.identity.application.authenticator.basicauth_5.1.2.jar          bundle         apache2
+org.wso2.carbon.identity.application.authenticator.facebook-5.1.2.jar           bundle         apache2
+org.wso2.carbon.identity.application.authenticator.fido_5.1.2.jar               bundle         apache2
+org.wso2.carbon.identity.application.authenticator.google-5.1.2.jar             bundle         apache2
+org.wso2.carbon.identity.application.authenticator.iwa_5.1.2.jar                bundle         apache2
+org.wso2.carbon.identity.application.authenticator.live-5.1.2.jar               bundle         apache2
+org.wso2.carbon.identity.application.authenticator.oidc-5.1.2.jar               bundle         apache2
+org.wso2.carbon.identity.application.authenticator.passive.sts-5.1.2.jar        bundle         apache2
+org.wso2.carbon.identity.application.authenticator.requestpath.oauth_5.1.2.jar  bundle         apache2
+org.wso2.carbon.identity.application.authenticator.samlsso-5.1.3.jar            bundle         apache2
+org.wso2.carbon.identity.application.authenticator.yahoo-5.1.2.jar              bundle         apache2
+org.wso2.carbon.identity.application.common_5.2.2.jar                           bundle         apache2
+org.wso2.carbon.identity.application.mgt.stub_5.2.2.jar                         bundle         apache2
+org.wso2.carbon.identity.application.mgt.ui_5.2.2.jar                           bundle         apache2
+org.wso2.carbon.identity.application.mgt_5.2.2.jar                              bundle         apache2
+org.wso2.carbon.identity.authenticator.iwa.stub_5.1.2.jar                       bundle         apache2
+org.wso2.carbon.identity.authenticator.iwa.ui_5.1.2.jar                         bundle         apache2
+org.wso2.carbon.identity.authenticator.iwa_5.1.2.jar                            bundle         apache2
+org.wso2.carbon.identity.authenticator.mutualssl_5.1.1.jar                      bundle         apache2
+org.wso2.carbon.identity.authenticator.saml2.sso.common_5.1.4.jar               bundle         apache2
+org.wso2.carbon.identity.authenticator.saml2.sso.stub_5.1.4.jar                 bundle         apache2
+org.wso2.carbon.identity.authenticator.saml2.sso.ui_5.1.4.jar                   bundle         apache2
+org.wso2.carbon.identity.authenticator.saml2.sso_5.1.4.jar                      bundle         apache2
+org.wso2.carbon.identity.authenticator.thrift_5.2.2.jar                         bundle         apache2
+org.wso2.carbon.identity.base_5.2.2.jar                                         bundle         apache2
+org.wso2.carbon.identity.core.ui_5.2.2.jar                                      bundle         apache2
+org.wso2.carbon.identity.core_5.2.2.jar                                         bundle         apache2
+org.wso2.carbon.identity.data.publisher.application.authentication_5.1.2.jar    bundle         apache2
+org.wso2.carbon.identity.entitlement.common_5.2.2.jar                           bundle         apache2
+org.wso2.carbon.identity.entitlement.stub_5.2.2.jar                             bundle         apache2
+org.wso2.carbon.identity.entitlement.ui_5.2.2.jar                               bundle         apache2
+org.wso2.carbon.identity.entitlement_5.2.2.jar                                  bundle         apache2
+org.wso2.carbon.identity.mgt.stub_5.2.2.jar                                     bundle         apache2
+org.wso2.carbon.identity.mgt.ui_5.2.2.jar                                       bundle         apache2
+org.wso2.carbon.identity.mgt_5.2.2.jar                                          bundle         apache2
+org.wso2.carbon.identity.notification.mgt.email_5.1.1.jar                       bundle         apache2
+org.wso2.carbon.identity.notification.mgt.json_5.1.1.jar                        bundle         apache2
+org.wso2.carbon.identity.notification.mgt_5.2.2.jar                             bundle         apache2
+org.wso2.carbon.identity.oauth.common_5.1.3.jar                                 bundle         apache2
+org.wso2.carbon.identity.oauth.stub_5.1.3.jar                                   bundle         apache2
+org.wso2.carbon.identity.oauth.ui_5.1.3.jar                                     bundle         apache2
+org.wso2.carbon.identity.oauth_5.1.3.jar                                        bundle         apache2
+org.wso2.carbon.identity.oidc.session_5.1.3.jar                                 bundle         apache2
+org.wso2.carbon.identity.provider_5.1.1.jar                                     bundle         apache2
+org.wso2.carbon.identity.provisioning.connector.google_5.1.1.jar                bundle         apache2
+org.wso2.carbon.identity.provisioning.connector.salesforce_5.1.1.jar            bundle         apache2
+org.wso2.carbon.identity.provisioning.connector.scim_5.1.1.jar                  bundle         apache2
+org.wso2.carbon.identity.provisioning.connector.spml_5.1.1.jar                  bundle         apache2
+org.wso2.carbon.identity.provisioning_5.2.2.jar                                 bundle         apache2
+org.wso2.carbon.identity.scim.common_5.1.2.jar                                  bundle         apache2
+org.wso2.carbon.identity.sso.agent_5.1.0.jar                                    bundle         apache2
+org.wso2.carbon.identity.sso.saml.stub_5.1.1.jar                                bundle         apache2
+org.wso2.carbon.identity.sso.saml.stub_5.1.2.jar                                bundle         apache2
+org.wso2.carbon.identity.sso.saml.ui_5.1.2.jar                                  bundle         apache2
+org.wso2.carbon.identity.sso.saml_5.1.2.jar                                     bundle         apache2
+org.wso2.carbon.identity.sts.mgt.stub_5.1.2.jar                                 bundle         apache2
+org.wso2.carbon.identity.sts.mgt.ui_5.1.2.jar                                   bundle         apache2
+org.wso2.carbon.identity.sts.mgt_5.1.2.jar                                      bundle         apache2
+org.wso2.carbon.identity.sts.passive.stub_5.1.2.jar                             bundle         apache2
+org.wso2.carbon.identity.sts.passive.ui_5.1.2.jar                               bundle         apache2
+org.wso2.carbon.identity.sts.passive_5.1.2.jar                                  bundle         apache2
+org.wso2.carbon.identity.sts.store_5.1.2.jar                                    bundle         apache2
+org.wso2.carbon.identity.tools.saml.validator.stub_5.1.1.jar                    bundle         apache2
+org.wso2.carbon.identity.tools.saml.validator.ui_5.1.1.jar                      bundle         apache2
+org.wso2.carbon.identity.tools.saml.validator_5.1.1.jar                         bundle         apache2
+org.wso2.carbon.identity.user.account.association.stub_5.1.1.jar                bundle         apache2
+org.wso2.carbon.identity.user.account.association_5.1.1.jar                     bundle         apache2
+org.wso2.carbon.identity.user.profile.stub_5.2.2.jar                            bundle         apache2
+org.wso2.carbon.identity.user.profile.ui_5.2.2.jar                              bundle         apache2
+org.wso2.carbon.identity.user.profile_5.2.2.jar                                 bundle         apache2
+org.wso2.carbon.identity.user.registration.stub_5.2.2.jar                       bundle         apache2
+org.wso2.carbon.identity.user.registration_5.2.2.jar                            bundle         apache2
+org.wso2.carbon.identity.user.store.configuration.deployer_5.2.2.jar            bundle         apache2
+org.wso2.carbon.identity.user.store.configuration.stub_5.2.2.jar                bundle         apache2
+org.wso2.carbon.identity.user.store.configuration.ui_5.2.2.jar                  bundle         apache2
+org.wso2.carbon.identity.user.store.configuration_5.2.2.jar                     bundle         apache2
+org.wso2.carbon.identity.user.store.count.stub_5.2.2.jar                        bundle         apache2
+org.wso2.carbon.identity.user.store.count_5.2.2.jar                             bundle         apache2
+org.wso2.carbon.identity.user.store.remote_5.1.1.jar                            bundle         apache2
+org.wso2.carbon.identity.workflow.impl.stub_5.1.2.jar                           bundle         apache2
+org.wso2.carbon.identity.workflow.impl.ui_5.1.2.jar                             bundle         apache2
+org.wso2.carbon.identity.workflow.impl_5.1.2.jar                                bundle         apache2
+org.wso2.carbon.identity.workflow.mgt.bps.stub_5.1.2.jar                        bundle         apache2
+org.wso2.carbon.identity.workflow.mgt.stub_5.2.2.jar                            bundle         apache2
+org.wso2.carbon.identity.workflow.mgt.ui_5.2.2.jar                              bundle         apache2
+org.wso2.carbon.identity.workflow.mgt_5.2.2.jar                                 bundle         apache2
+org.wso2.carbon.identity.workflow.template_5.1.1.jar                            bundle         apache2
+org.wso2.carbon.idp.mgt.stub_5.2.2.jar                                          bundle         apache2
+org.wso2.carbon.idp.mgt.ui_5.2.2.jar                                            bundle         apache2
+org.wso2.carbon.idp.mgt_5.2.2.jar                                               bundle         apache2
+org.wso2.carbon.ldap.server_5.1.1.jar                                           bundle         apache2
+org.wso2.carbon.logging-4.4.9.jar                                               bundle         apache2
+org.wso2.carbon.logging.admin.stub_4.5.4.jar                                    bundle         apache2
+org.wso2.carbon.logging.admin.ui_4.5.4.jar                                      bundle         apache2
+org.wso2.carbon.logging.service_4.5.4.jar                                       bundle         apache2
+org.wso2.carbon.logging.view.stub_4.5.4.jar                                     bundle         apache2
+org.wso2.carbon.logging.view.ui_4.5.4.jar                                       bundle         apache2
+org.wso2.carbon.logging_4.4.9.jar                                               bundle         apache2
+org.wso2.carbon.metrics.common_1.2.2.jar                                        bundle         apache2
+org.wso2.carbon.metrics.das.reporter_1.2.2.jar                                  bundle         apache2
+org.wso2.carbon.metrics.data.common_1.2.2.jar                                   bundle         apache2
+org.wso2.carbon.metrics.data.service.stub_1.2.2.jar                             bundle         apache2
+org.wso2.carbon.metrics.data.service_1.2.2.jar                                  bundle         apache2
+org.wso2.carbon.metrics.impl_1.2.2.jar                                          bundle         apache2
+org.wso2.carbon.metrics.jdbc.reporter_1.2.2.jar                                 bundle         apache2
+org.wso2.carbon.metrics.manager_1.2.2.jar                                       bundle         apache2
+org.wso2.carbon.metrics.view.ui_1.2.2.jar                                       bundle         apache2
+org.wso2.carbon.mex_5.1.2.jar                                                   bundle         apache2
+org.wso2.carbon.module.mgt_4.7.0.jar                                            bundle         apache2
+org.wso2.carbon.ndatasource.common_4.4.9.jar                                    bundle         apache2
+org.wso2.carbon.ndatasource.core_4.4.9.jar                                      bundle         apache2
+org.wso2.carbon.ndatasource.rdbms_4.4.9.jar                                     bundle         apache2
+org.wso2.carbon.operation.mgt_4.7.0.jar                                         bundle         apache2
+org.wso2.carbon.osgi.security_4.4.9.jar                                         bundle         apache2
+org.wso2.carbon.policyeditor.ui_5.2.2.jar                                       bundle         apache2
+org.wso2.carbon.policyeditor_5.2.2.jar                                          bundle         apache2
+org.wso2.carbon.qpid.stub_4.5.4.jar                                             bundle         apache2
+org.wso2.carbon.queuing_4.4.9.jar                                               bundle         apache2
+org.wso2.carbon.registry.admin.api_4.5.4.jar                                    bundle         apache2
+org.wso2.carbon.registry.api_4.4.9.jar                                          bundle         apache2
+org.wso2.carbon.registry.common.ui_4.5.4.jar                                    bundle         apache2
+org.wso2.carbon.registry.common_4.5.4.jar                                       bundle         apache2
+org.wso2.carbon.registry.core_4.4.9.jar                                         bundle         apache2
+org.wso2.carbon.registry.indexing_4.5.4.jar                                     bundle         apache2
+org.wso2.carbon.registry.profiles.stub_4.5.4.jar                                bundle         apache2
+org.wso2.carbon.registry.profiles.ui_4.5.4.jar                                  bundle         apache2
+org.wso2.carbon.registry.profiles_4.5.4.jar                                     bundle         apache2
+org.wso2.carbon.registry.properties.stub_4.5.4.jar                              bundle         apache2
+org.wso2.carbon.registry.properties.ui_4.5.4.jar                                bundle         apache2
+org.wso2.carbon.registry.properties_4.5.4.jar                                   bundle         apache2
+org.wso2.carbon.registry.resource.stub_4.5.4.jar                                bundle         apache2
+org.wso2.carbon.registry.resource.ui_4.5.4.jar                                  bundle         apache2
+org.wso2.carbon.registry.resource_4.5.4.jar                                     bundle         apache2
+org.wso2.carbon.registry.search.stub_4.5.4.jar                                  bundle         apache2
+org.wso2.carbon.registry.search.ui_4.5.4.jar                                    bundle         apache2
+org.wso2.carbon.registry.search_4.5.4.jar                                       bundle         apache2
+org.wso2.carbon.registry.server_4.4.9.jar                                       bundle         apache2
+org.wso2.carbon.registry.servlet_4.5.4.jar                                      bundle         apache2
+org.wso2.carbon.roles.mgt.stub_4.4.9.jar                                        bundle         apache2
+org.wso2.carbon.roles.mgt.ui_4.4.9.jar                                          bundle         apache2
+org.wso2.carbon.roles.mgt_4.4.9.jar                                             bundle         apache2
+org.wso2.carbon.securevault_4.4.9.jar                                           bundle         apache2
+org.wso2.carbon.security.mgt.stub_5.2.2.jar                                     bundle         apache2
+org.wso2.carbon.security.mgt.ui_5.2.2.jar                                       bundle         apache2
+org.wso2.carbon.security.mgt_5.2.2.jar                                          bundle         apache2
+org.wso2.carbon.server-4.4.9.jar                                                bundle         apache2
+org.wso2.carbon.server.admin.common_4.4.9.jar                                   bundle         apache2
+org.wso2.carbon.server.admin.stub_4.4.9.jar                                     bundle         apache2
+org.wso2.carbon.server.admin.ui_4.4.9.jar                                       bundle         apache2
+org.wso2.carbon.server.admin_4.4.9.jar                                          bundle         apache2
+org.wso2.carbon.service.mgt_4.7.0.jar                                           bundle         apache2
+org.wso2.carbon.statistics.stub_4.5.4.jar                                       bundle         apache2
+org.wso2.carbon.statistics.ui_4.5.4.jar                                         bundle         apache2
+org.wso2.carbon.statistics_4.5.4.jar                                            bundle         apache2
+org.wso2.carbon.sts.stub_5.1.2.jar                                              bundle         apache2
+org.wso2.carbon.sts.ui_5.1.2.jar                                                bundle         apache2
+org.wso2.carbon.sts_5.1.2.jar                                                   bundle         apache2
+org.wso2.carbon.tenant.common.stub_4.5.4.jar                                    bundle         apache2
+org.wso2.carbon.tenant.common_4.5.4.jar                                         bundle         apache2
+org.wso2.carbon.tenant.dispatcher_4.6.0.jar                                     bundle         apache2
+org.wso2.carbon.tenant.keystore.mgt_4.6.0.jar                                   bundle         apache2
+org.wso2.carbon.tenant.mgt.core_4.6.0.jar                                       bundle         apache2
+org.wso2.carbon.tenant.mgt.stub_4.6.0.jar                                       bundle         apache2
+org.wso2.carbon.tenant.mgt.ui_4.6.0.jar                                         bundle         apache2
+org.wso2.carbon.tenant.mgt_4.6.0.jar                                            bundle         apache2
+org.wso2.carbon.tenant.redirector.servlet.stub_4.6.0.jar                        bundle         apache2
+org.wso2.carbon.tenant.redirector.servlet.ui_4.6.0.jar                          bundle         apache2
+org.wso2.carbon.tenant.redirector.servlet_4.6.0.jar                             bundle         apache2
+org.wso2.carbon.tenant.sso.redirector.ui_4.6.0.jar                              bundle         apache2
+org.wso2.carbon.tenant.theme.mgt_4.6.0.jar                                      bundle         apache2
+org.wso2.carbon.tomcat.ext_4.4.9.jar                                            bundle         apache2
+org.wso2.carbon.tomcat.patch_4.7.0.jar                                          bundle         apache2
+org.wso2.carbon.tomcat_4.4.9.jar                                                bundle         apache2
+org.wso2.carbon.tracer.stub_4.5.4.jar                                           bundle         apache2
+org.wso2.carbon.tracer.ui_4.5.4.jar                                             bundle         apache2
+org.wso2.carbon.tracer_4.5.4.jar                                                bundle         apache2
+org.wso2.carbon.ui.menu.general_4.4.9.jar                                       bundle         apache2
+org.wso2.carbon.ui.menu.registry_4.4.5.jar                                      bundle         apache2
+org.wso2.carbon.ui.menu.tools_4.4.7.jar                                         bundle         apache2
+org.wso2.carbon.ui_4.4.9.jar                                                    bundle         apache2
+org.wso2.carbon.um.ws.api.stub_5.1.2.jar                                        bundle         apache2
+org.wso2.carbon.um.ws.api_5.1.2.jar                                             bundle         apache2
+org.wso2.carbon.um.ws.service_5.1.2.jar                                         bundle         apache2
+org.wso2.carbon.unifiedendpoint.core_4.4.9.jar                                  bundle         apache2
+org.wso2.carbon.user.api_4.4.9.jar                                              bundle         apache2
+org.wso2.carbon.user.core_4.4.9.jar                                             bundle         apache2
+org.wso2.carbon.user.mgt.common_5.2.2.jar                                       bundle         apache2
+org.wso2.carbon.user.mgt.stub_5.2.2.jar                                         bundle         apache2
+org.wso2.carbon.user.mgt.ui_5.2.2.jar                                           bundle         apache2
+org.wso2.carbon.user.mgt.workflow.stub_5.2.2.jar                                bundle         apache2
+org.wso2.carbon.user.mgt.workflow.ui_5.1.1.jar                                  bundle         apache2
+org.wso2.carbon.user.mgt.workflow_5.1.1.jar                                     bundle         apache2
+org.wso2.carbon.user.mgt_5.2.2.jar                                              bundle         apache2
+org.wso2.carbon.utils_4.4.9.jar                                                 bundle         apache2
+org.wso2.carbon.webapp.deployer_4.7.0.jar                                       bundle         apache2
+org.wso2.carbon.webapp.mgt_4.7.0.jar                                            bundle         apache2
+org.wso2.carbon.xfer_4.2.0.jar                                                  bundle         apache2
+org.wso2.charon.core_2.0.7.jar                                                  bundle         apache2
+org.wso2.ciphertool-1.0.0-wso2v3.jar                                            bundle         apache2
+org.wso2.identity.styles_5.2.0.jar                                              bundle         apache2
+org.wso2.orbit.asm4.asm4-all_4.0.0.wso2v1.jar                                   bundle         apache2
+org.wso2.securevault_1.0.0.wso2v2.jar                                           bundle         apache2
+org.wso2.stratos.identity.dashboard.ui_2.2.1.jar                                bundle         apache2
+patch.jar                                                                       jarinbundle    epl1
+pdepublishing-ant.jar                                                           jar            epl1
+pdepublishing.jar                                                               jar            epl1
+perf4j_0.9.12.wso2v1.jar                                                        bundle         apache2
+poi-ooxml_3.14.0.wso2v1.jar                                                     bundle         apache2
+poi-scratchpad_3.14.0.wso2v1.jar                                                bundle         apache2
+poi_3.14.0.wso2v1.jar                                                           bundle         apache2
+rampart-1.6.1-wso2v22.mar                                                       bundle         apache2
+rampart-core_1.6.1.wso2v22.jar                                                  bundle         apache2
+rampart-policy_1.6.1.wso2v22.jar                                                bundle         apache2
+rampart-trust_1.6.1.wso2v22.jar                                                 bundle         apache2
+rome_0.9.0.wso2v1.jar                                                           bundle         apache2
+saxon.bps_9.0.0.x-wso2v1.jar                                                    bundle         mpl11
+saxon.he_9.4.0.wso2v1.jar                                                       bundle         mpl10
+scribe-1.3.1.jar                                                                jarinbundle    mit
+serp_1.13.1.wso2v1.jar                                                          bundle         bsd
+shared-asn1-0.9.19.jar                                                          jarinbundle    apache2
+shared-asn1-codec-0.9.19.jar                                                    jarinbundle    apache2
+shared-cursor-0.9.19.jar                                                        jarinbundle    apache2
+shared-dsml-parser-0.9.19.jar                                                   jarinbundle    apache2
+shared-i18n-0.9.19.jar                                                          jarinbundle    apache2
+shared-ldap-0.9.19.jar                                                          jarinbundle    apache2
+shared-ldap-constants-0.9.19.jar                                                jarinbundle    apache2
+shared-ldap-converter-0.9.19.jar                                                jarinbundle    apache2
+shared-ldap-jndi-0.9.19.jar                                                     jarinbundle    apache2
+shared-ldap-schema-0.9.19.jar                                                   jarinbundle    apache2
+shared-ldap-schema-dao-0.9.19.jar                                               jarinbundle    apache2
+shared-ldap-schema-loader-0.9.19.jar                                            jarinbundle    apache2
+shared-ldap-schema-manager-0.9.19.jar                                           jarinbundle    apache2
+shared-ldif-0.9.19.jar                                                          jarinbundle    apache2
+siddhi-core_3.1.1.jar                                                           bundle         apache2
+slf4j.api_1.6.1.jar                                                             bundle         mit
+slf4j.api_1.7.13.jar                                                            bundle         mit
+slf4j.api_1.7.21.jar                                                            bundle         mit
+slf4j.log4j12_1.6.1.jar                                                         bundle         mit
+slf4j.log4j12_1.7.13.jar                                                        bundle         mit
+slf4j.log4j12_1.7.21.jar                                                        bundle         mit
+soa.model.core_1.5.0.wso2v4.jar                                                 bundle         apache2
+solr_5.2.1.wso2v1.jar                                                           bundle         apache2
+spatial4j_0.4.1.wso2v1.jar                                                      bundle         apache2
+spring-aop-3.0.7.RELEASE.jar                                                    bundle         apache2
+spring-asm-3.0.7.RELEASE.jar                                                    bundle         apache2
+spring-beans-3.0.7.RELEASE.jar                                                  bundle         apache2
+spring-context-3.0.7.RELEASE.jar                                                bundle         apache2
+spring-core-3.0.7.RELEASE.jar                                                   bundle         apache2
+spring-expression-3.0.7.RELEASE.jar                                             bundle         apache2
+spring-web-3.0.7.RELEASE.jar                                                    bundle         apache2
+spring.framework_3.2.9.wso2v1.jar                                               bundle         apache2
+stax2-api-3.1.4.jar                                                             bundle         bsd
+step2-common-1.0.0-wso2v2.jar                                                   bundle         apache2
+step2-consumer-1.0.0-wso2v2.jar                                                 bundle         apache2
+step2_1.0.0.wso2v2.jar                                                          bundle         apache2
+svn-client-adapter_1.10.9.wso2v1.jar                                            bundle         apache2
+tcpmon-1.0.jar                                                                  jar            bsd
+tiles-jsp_2.0.5.wso2v1.jar                                                      bundle         apache2
+tomcat-annotations-api-7.0.70.jar                                               jar            apache2
+tomcat-catalina-ha_7.0.70.wso2v1.jar                                            bundle         apache2
+tomcat-el-api_7.0.70.wso2v1.jar                                                 bundle         apache2
+tomcat-jsp-api_7.0.70.wso2v1.jar                                                bundle         apache2
+tomcat-juli-7.0.70.jar                                                          jar            apache2
+tomcat-servlet-api_7.0.70.wso2v1.jar                                            bundle         apache2
+tomcat_7.0.70.wso2v1.jar                                                        bundle         apache2
+tranql-connector_1.1.0.wso2v1.jar                                               bundle         apache2
+tyrus-standalone-client_1.7.0.wso2v1.jar                                        bundle         cddl+gpl
+u2flib-server-core-0.14.0.jar                                                   jarinbundle    bsd
+velocity-1.7.jar                                                                bundle         apache2
+waffle-jna_1.6.0.wso2v5.jar                                                     bundle         epl1
+woden_1.0.0.M9-wso2v1.jar                                                       bundle         apache2
+woodstox-core-asl-4.4.1.jar                                                     bundle         apache2
+wsdl4j-1.6.3.jar                                                                jar            cpl1
+wsdl4j_1.6.2.wso2v4.jar                                                         bundle         apache2
+wso2-uri-templates_1.6.2.jar                                                    bundle         apache2
+wss4j_1.5.11.wso2v15.jar                                                        bundle         apache2
+xalan-2.7.2.wso2v2.jar                                                          bundle         apache2
+xercesImpl-2.8.1.wso2v2.jar                                                     bundle         apache2
+xml-apis-1.4.01.jar                                                             jar            apache2
+xml-resolver-1.2.jar                                                            jar            apache2
+xmlbeans-2.3.0.jar                                                              jarinbundle    apache2
+xmlbeans_2.3.0.wso2v1.jar                                                       bundle         apache2
+xmlschema-core-2.1.0.jar                                                        bundle         apache2
+XmlSchema_1.4.7.wso2v3.jar                                                      bundle         apache2
+xmlsec-1.5.8.jar                                                                bundle         apache2
 
 
 

--- a/modules/dbscripts/ids_connectdb.sql
+++ b/modules/dbscripts/ids_connectdb.sql
@@ -470,6 +470,12 @@ INSERT INTO `scope_supp_login_hint_format`(param_id,format_id) VALUES(3,1);
 INSERT INTO `scope_supp_login_hint_format`(param_id,format_id) VALUES(4,1);
 INSERT INTO `scope_supp_login_hint_format`(param_id,format_id) VALUES(5,1);
 
+DROP TABLE IF EXISTS `sms_hashkey_contextid_mapping`;
+CREATE TABLE `sms_hashkey_contextid_mapping` (
+  `hashkey` varchar(255) DEFAULT NULL,
+  `contextid` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -136,6 +136,10 @@
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hashids</groupId>
+            <artifactId>hashids</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -847,14 +847,6 @@
 
 	<file>
             <source>
-                ../dbscripts/ids_operatorsdb.sql
-            </source>
-            <outputDirectory>wso2telcoids-${pom.version}/dbscripts/ids</outputDirectory>
-        <fileMode>644</fileMode>
-        </file>
-
-	<file>
-            <source>
                 ../dbscripts/ids_regdb.sql
             </source>
             <outputDirectory>wso2telcoids-${pom.version}/dbscripts/ids</outputDirectory>
@@ -896,6 +888,7 @@
                 <include>org.codehaus.jettison:jettison:jar</include>
                 <include>org.apache.httpcomponents:httpasyncclient:jar</include>
                 <include>org.apache.httpcomponents:httpcore-nio:jar</include>
+                <include>org.hashids:hashids:jar</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -1286,6 +1286,11 @@
                 <artifactId>jettison</artifactId>
                 <version>${jettison.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.hashids</groupId>
+                <artifactId>hashids</artifactId>
+                <version>${hash.ids.version}</version>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>
@@ -1525,6 +1530,7 @@
         <http.core.nio.version>4.3</http.core.nio.version>
         <jettison.version>1.1</jettison.version>
         <httpasyncclient.version>4.0</httpasyncclient.version>
+        <hash.ids.version>1.0.1</hash.ids.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This PR adds sms_hashkey_contextid_mapping table which is needed for SMSAuthenticator.
Also this adds hashids dependency to repository/components/libs.
And, the LICENSE is also modified.

https://github.com/WSO2Telco/component-ids/pull/83 depends on this PR.